### PR TITLE
Corriger le bug du décalage d'affichage du header sur les écrans petits

### DIFF
--- a/components/app-header/app-header-component.jsx
+++ b/components/app-header/app-header-component.jsx
@@ -12,7 +12,7 @@ import HeaderMenuButtonMobile from "./menu-button-mobile";
 
 const styles = () => ({
   bolderMobileTitle: {
-    fontSize: 25,
+    fontSize: 17,
     fontWeight: "bold",
   },
   bolderTitle: {
@@ -20,7 +20,7 @@ const styles = () => ({
     fontWeight: "bold",
   },
   lighterMobileTitle: {
-    fontSize: 25,
+    fontSize: 17,
     fontWeight: "regular",
   },
   lighterTitle: {


### PR DESCRIPTION
Carte Trello : https://trello.com/c/qttqmlG5/143-responsivness-bug-affichage-d%C3%A9calage-de-l%C3%A9cran

*Avant*
![image](https://user-images.githubusercontent.com/13604533/79322543-43fa4900-7f0d-11ea-94c7-e3b1e96e49f1.png)

*Apres*
![image](https://user-images.githubusercontent.com/13604533/79322578-51afce80-7f0d-11ea-9111-86be630aee6c.png)
