### PR TITLE
Ajouter les éléments d'accessibilité

### DIFF
--- a/components/articles-inputs/parameter/Parameter.module.scss
+++ b/components/articles-inputs/parameter/Parameter.module.scss
@@ -5,7 +5,7 @@ $input-margin: 0.3rem;
 .baseValue {
   font-weight: bold;
   margin-left: $input-margin;
-  text-decoration-color: $reform-bg-color;
+  text-decoration-color: $amendement-bg-color;
   text-decoration-line: line-through;
 }
 
@@ -33,7 +33,7 @@ $input-margin: 0.3rem;
 
 .reformValueModified {
   padding: 0.1rem;
-  background-color: $reform-bg-color;
+  background-color: $amendement-bg-color;
 }
 
 .noOverflow > span {

--- a/components/articles/article-header.module.scss
+++ b/components/articles/article-header.module.scss
@@ -26,7 +26,7 @@
   
   button, svg {
     text-transform: none !important;
-    color: $reform-text-color !important;
+    color: $amendement-text-color !important;
     font-family: $default-font-family !important;
   }
 }

--- a/components/articles/article-tranches/bouton-ajouter-tranche.module.scss
+++ b/components/articles/article-tranches/bouton-ajouter-tranche.module.scss
@@ -1,5 +1,5 @@
 @import 'styles/variables.scss';
 
 .amendementText {
-  color: $reform-text-color !important;
+  color: $amendement-text-color !important;
 }

--- a/components/articles/article-tranches/bouton-supprimer-tranche.module.scss
+++ b/components/articles/article-tranches/bouton-supprimer-tranche.module.scss
@@ -1,5 +1,5 @@
 @import 'styles/variables.scss';
 
 .amendementText {
-  color: $reform-text-color !important;
+  color: $amendement-text-color !important;
 }

--- a/components/articles/articles.module.scss
+++ b/components/articles/articles.module.scss
@@ -4,7 +4,6 @@
   font-size: 18px;
   font-family: $law-font-family;
   line-height: 1.6;
-  text-align: justify;
 }
 
 .newTranche {

--- a/components/articles/articles.module.scss
+++ b/components/articles/articles.module.scss
@@ -7,5 +7,5 @@
 }
 
 .newTranche {
-  color: $reform-text-color;
+  color: $amendement-text-color;
 }

--- a/components/articles/expandable-panels/PrimaryExpandablePanel.jsx
+++ b/components/articles/expandable-panels/PrimaryExpandablePanel.jsx
@@ -6,10 +6,13 @@ import { PureComponent } from "react";
 import styles from "./PrimaryExpandablePanel.module.scss";
 
 export class PrimaryExpandablePanel extends PureComponent {
+  static lastId = 0;
+
   constructor(props) {
     super(props);
+    PrimaryExpandablePanel.lastId += 1;
     const { expanded } = this.props;
-    this.state = { expanded };
+    this.state = { expanded, id: PrimaryExpandablePanel.lastId };
     this.onExpandedChange = this.onExpandedChange.bind(this);
   }
 
@@ -20,10 +23,19 @@ export class PrimaryExpandablePanel extends PureComponent {
 
   render() {
     const { children, subTitle, title } = this.props;
-    const { expanded } = this.state;
+    const { expanded, id } = this.state;
     return (
       <div>
-        <div className={styles.header}>
+        <div
+          aria-controls={`primary-panel${id}-content`}
+          aria-disabled="false"
+          aria-expanded={expanded}
+          className={styles.header}
+          id={`primary-panel${id}-header`}
+          role="button"
+          tabIndex="0"
+          onClick={this.onExpandedChange}
+          onKeyDown={e => e.key === "Enter" && this.onExpandedChange()}>
           <div className={styles.text}>
             <span className={styles.title}>{title}</span>
             <span className={styles.subTitle}>
@@ -34,13 +46,13 @@ export class PrimaryExpandablePanel extends PureComponent {
             </span>
           </div>
           <div>
-            <button className={styles.btn} type="button" onClick={this.onExpandedChange}>
+            <span aria-disabled="false" aria-hidden="true" className={styles.btn} type="button">
               {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            </button>
+            </span>
           </div>
         </div>
         {expanded && (
-          <div className={styles.content}>
+          <div aria-labelledby={`primary-panel${id}-header`} className={styles.content} id={`primary-panel${id}-content`} role="region">
             {children}
           </div>
         )}

--- a/components/articles/expandable-panels/PrimaryExpandablePanel.module.scss
+++ b/components/articles/expandable-panels/PrimaryExpandablePanel.module.scss
@@ -9,6 +9,7 @@ $padding-y: 15px;
   display: flex;
   align-items: center;
   flex-direction: row;
+  cursor: pointer;
 
   .title {
     font-weight: bold;
@@ -21,16 +22,10 @@ $padding-y: 15px;
     font-family: $law-font-family;
   }
 
-  .btn {
-    cursor: pointer;
-    border: none;
-    background-color: inherit;
-  }
+}
 
-  .btn:hover {
-    background-color: #e1e1e1;
-  }
-
+.header:hover {
+  background-color: #e1e1e1;
 }
 
 .text {

--- a/components/articles/expandable-panels/SecondaryExpandablePanel.jsx
+++ b/components/articles/expandable-panels/SecondaryExpandablePanel.jsx
@@ -6,10 +6,13 @@ import { PureComponent } from "react";
 import styles from "./SecondaryExpandablePanel.module.scss";
 
 export class SecondaryExpandablePanel extends PureComponent {
+  static lastId = 0;
+
   constructor(props) {
     super(props);
+    SecondaryExpandablePanel.lastId += 1;
     const { expanded } = this.props;
-    this.state = { expanded };
+    this.state = { expanded, id: SecondaryExpandablePanel.lastId };
     this.onExpandedChange = this.onExpandedChange.bind(this);
   }
 
@@ -20,10 +23,19 @@ export class SecondaryExpandablePanel extends PureComponent {
 
   render() {
     const { children, subTitle, title } = this.props;
-    const { expanded } = this.state;
+    const { expanded, id } = this.state;
     return (
       <div className={styles.container}>
-        <div className={styles.header}>
+        <div
+          aria-controls={`secondary-panel${id}-content`}
+          aria-disabled="false"
+          aria-expanded={expanded}
+          className={styles.header}
+          id={`secondary-panel${id}-header`}
+          role="button"
+          tabIndex="0"
+          onClick={this.onExpandedChange}
+          onKeyDown={e => e.key === "Enter" && this.onExpandedChange()}>
           <div className={styles.text}>
             <span className={styles.title}>{title}</span>
             <span className={styles.subTitle}>
@@ -34,13 +46,13 @@ export class SecondaryExpandablePanel extends PureComponent {
             </span>
           </div>
           <div>
-            <button className={styles.btn} type="button" onClick={this.onExpandedChange}>
+            <span aria-disabled="false" aria-hidden="true" className={styles.btn} type="button">
               {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-            </button>
+            </span>
           </div>
         </div>
         {expanded && (
-          <div className={styles.content}>
+          <div aria-labelledby={`secondary-panel${id}-header`} className={styles.content} id={`secondary-panel${id}-content`} role="region">
             {children}
           </div>
         )}

--- a/components/articles/expandable-panels/SecondaryExpandablePanel.module.scss
+++ b/components/articles/expandable-panels/SecondaryExpandablePanel.module.scss
@@ -14,6 +14,7 @@ $header-padding-left: 7px;
   display: flex;
   align-items: center;
   flex-direction: row;
+  cursor: pointer;
 
   .title {
     color: #565656;
@@ -28,16 +29,10 @@ $header-padding-left: 7px;
     font-family: $law-font-family;
   }
 
-  .btn {
-    cursor: pointer;
-    border: none;
-    background-color: inherit;
-  }
+}
 
-  .btn:hover {
-    background-color: #e1e1e1;
-  }
-
+.header:hover {
+  background-color: #e1e1e1;
 }
 
 .text {

--- a/components/carte-etat/carte-etat-component.module.scss
+++ b/components/carte-etat/carte-etat-component.module.scss
@@ -38,7 +38,7 @@
     font-weight: bold;
     font-size: 40px;
     color: #000000;
-    background-color: $reform-bg-color;
+    background-color: $amendement-bg-color;
     padding: 0.1rem;
   }
 }

--- a/components/carte-etat/simpop-tableur-infos-deciles.module.scss
+++ b/components/carte-etat/simpop-tableur-infos-deciles.module.scss
@@ -28,7 +28,7 @@
 
 .reform {
   color: #000000;
-  background-color: $reform-bg-color;
+  background-color: $amendement-bg-color;
 
   border-radius: 0.3em;
   font-family: Lato;

--- a/components/cartes-impact/gagnants-perdants/gagnants-perdants-component.module.scss
+++ b/components/cartes-impact/gagnants-perdants/gagnants-perdants-component.module.scss
@@ -17,7 +17,7 @@
 }
 
 .reformValue {
-  background-color: $reform-bg-color;
+  background-color: $amendement-bg-color;
   padding: 0.1rem;
 }
 
@@ -51,7 +51,7 @@
 .detailsReformValue {
   color: #000000;
   font-weight: bold;
-  background-color: $reform-bg-color;
+  background-color: $amendement-bg-color;
 }
 
 .detailsReformUnit {

--- a/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
+++ b/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
@@ -64,7 +64,11 @@ function TextePresentationLeximpactPop({ classes }) {
 
       <Divider className={classes.dividerMarge} />
 
-      <p>Les paramètres modifiables dans l&apos;Article 197 du CGI sont : </p>
+      <p>
+        Les paramètres modifiables dans l&apos;Article 197 du
+        <abbr title="Code général des impôts">CGI</abbr>
+        sont :
+      </p>
       <ul>
         <li>le barème de l&apos;impôt sur le revenu,</li>
         <li>les plafonds du quotient familial,</li>

--- a/components/presentation-cgu/texte-presentation-open-leximpact.jsx
+++ b/components/presentation-cgu/texte-presentation-open-leximpact.jsx
@@ -22,7 +22,8 @@ function TextePresentationOpenLeximpact({ classes }) {
   return (
     <Paper className={classes.paperItem}>
       <h2>LexImpact IR en accès libre</h2>
-      <p>La version en accès libre de LexImpact IR permet à&nbsp;toutes et tous
+      <p>
+        La version en accès libre de LexImpact IR permet à&nbsp;toutes et tous
         de simuler les impacts d&apos;une réforme sur des foyers
         fiscaux types. Le&nbsp;service ne vous permet pas de simuler votre
         situation personnelle.
@@ -47,7 +48,11 @@ function TextePresentationOpenLeximpact({ classes }) {
 
       <Divider className={classes.dividerMarge} />
 
-      <p>Les paramètres modifiables dans l&apos;Article 197 du CGI sont :</p>
+      <p>
+        Les paramètres modifiables dans l&apos;Article 197 du
+        <abbr title="Code général des impôts">CGI</abbr>
+        sont :
+      </p>
       <ul>
         <li>le barème de l&apos;impôt sur le revenu,</li>
         <li>les plafonds du quotient familial,</li>
@@ -56,7 +61,7 @@ function TextePresentationOpenLeximpact({ classes }) {
       </ul>
 
       <p>
-        La version en accès libre de LexImpact permet également de modifier 
+        La version en accès libre de LexImpact permet également de modifier
         le revenu net à déclarer des foyers fiscaux types prédéfinis sur l&apos;interface.
       </p>
 

--- a/components/simulation-menu/legende/Legende.module.scss
+++ b/components/simulation-menu/legende/Legende.module.scss
@@ -37,6 +37,6 @@
 .reform {
   font-weight: bold;
   color: black;
-  background-color: $reform-bg-color;
+  background-color: $amendement-bg-color;
   padding: 0.1rem;
 }

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -52,7 +52,7 @@ class MyDocument extends Document {
     const { pageContext } = this.props;
 
     return (
-      <html dir="ltr" lang="en">
+      <html dir="ltr" lang="fr">
         <Head>
           <meta charSet="utf-8" />
           {/* Use minimum-scale=1 to enable GPU rasterization */}

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,5 +1,5 @@
-$reform-bg-color: rgb(222, 213, 0);
-$reform-text-color: #A6A00C;
+$amendement-bg-color: rgb(222, 213, 0);
+$amendement-text-color: #A6A00C;
 $plf-color: rgb(255, 107, 107);
 $default-font-family: Lato;
 $law-font-family: Lora;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -1,5 +1,5 @@
 $amendement-bg-color: rgb(222, 213, 0);
-$amendement-text-color: #A6A00C;
+$amendement-text-color: #746F08;
 $plf-color: rgb(255, 107, 107);
 $default-font-family: Lato;
 $law-font-family: Lora;

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -89,7 +89,7 @@ const theme = createMuiTheme({
     },
     secondary: {
       light: "#FF6B6B",
-      main: "#00A3FF",
+      main: "#343BFF",
       // dark: will be calculated from palette.secondary.main,
       contrastText: "#FFFFFF",
     },


### PR DESCRIPTION
- [x] GÉNÉRAL / Ajouter la langue "français" dans le code notre interface
- [x] CONTRASTE / Changer la couleur des boutons "estimer" #343BFF
- [x] CONTRASTE / Changer la couleur des boutons "jaunes" #746F08
- [x] LISIBILITÉ DU CONTENU / Définir les abbréviations
- [ ] ~ORGANISATION DU CONTENU / Indiquer si le lien hypertexte ouvre un nouvel onglet~. -> Pas besoin de spécifier autre chose dans le code : les liens ne s'ouvrent pas avec du JS mais directement avec l'attribut HTML `target="_blank"` ce que le navigateur peut interpreter.
- [x] LISIBILITÉ / Enlever la justification dans l'article
- [x] Rendre les expansions panels accessibles (= ajouter les arialabel)
