### PR TITLE
Intervertir les styles des boutons info et logout

### DIFF
--- a/components/app-header/login-button-mobile.jsx
+++ b/components/app-header/login-button-mobile.jsx
@@ -8,14 +8,8 @@ import { PureComponent } from "react";
 import { logOut, showConnexionPopin } from "../../redux/actions";
 
 const styles = () => ({
-  button: {
-    "&:hover": {
-      color: "#FFFFFF",
-    },
-    backgroundColor: "#FFFFFF",
-    color: "#646008",
-    fontSize: "12px",
-    textTransform: "uppercase",
+  menuButtonRoot: {
+    color: "#FFFFFF",
   },
 });
 
@@ -38,10 +32,7 @@ class LoginButtonMobile extends PureComponent {
     const { classes, isUserLogged } = this.props;
     return (
       <Button
-        className={classes.button}
-        color="primary"
-        size="small"
-        variant="contained"
+        className={classes.menuButtonRoot}
         onClick={this.onClick}>
         {isUserLogged ? <ExitToAppIcon /> : <VPNKeyIcon />}
       </Button>

--- a/components/app-header/login-button.jsx
+++ b/components/app-header/login-button.jsx
@@ -11,14 +11,8 @@ const styles = () => ({
   avatarIcon: {
     marginRight: "9px",
   },
-  button: {
-    "&:hover": {
-      color: "#FFFFFF",
-    },
-    backgroundColor: "#FFFFFF",
-    color: "#646008",
-    fontSize: "16px",
-    textTransform: "uppercase",
+  menuButtonRoot: {
+    color: "#FFFFFF",
   },
 });
 
@@ -41,10 +35,7 @@ class LoginButton extends PureComponent {
     const { classes, isUserLogged } = this.props;
     return (
       <Button
-        className={classes.button}
-        color="primary"
-        size="medium"
-        variant="contained"
+        className={classes.menuButtonRoot}
         onClick={this.onClick}>
         {isUserLogged
           ? <ExitToAppIcon classes={{ root: classes.avatarIcon }} />

--- a/components/app-header/menu-button-mobile.jsx
+++ b/components/app-header/menu-button-mobile.jsx
@@ -6,15 +6,24 @@ import PropTypes from "prop-types";
 import { showEnSavoirPlusPopin } from "../../redux/actions";
 
 const styles = {
-  menuButtonRoot: {
-    color: "#FFFFFF",
+  button: {
+    "&:hover": {
+      color: "#FFFFFF",
+    },
+    backgroundColor: "#FFFFFF",
+    color: "#646008",
+    fontSize: "16px",
+    textTransform: "uppercase",
   },
 };
 
 function HeaderMenuButton({ classes }) {
   return (
     <Button
-      classes={{ root: classes.menuButtonRoot }}
+      className={classes.button}
+      color="primary"
+      size="medium"
+      variant="contained"
       onClick={showEnSavoirPlusPopin}>
       <MenuIcon fontSize="small" />
     </Button>

--- a/components/app-header/menu-button.jsx
+++ b/components/app-header/menu-button.jsx
@@ -6,15 +6,24 @@ import PropTypes from "prop-types";
 import { showEnSavoirPlusPopin } from "../../redux/actions";
 
 const styles = {
-  menuButtonRoot: {
-    color: "#FFFFFF",
+  button: {
+    "&:hover": {
+      color: "#FFFFFF",
+    },
+    backgroundColor: "#FFFFFF",
+    color: "#646008",
+    fontSize: "16px",
+    textTransform: "uppercase",
   },
 };
 
 function HeaderMenuButton({ classes }) {
   return (
     <Button
-      classes={{ root: classes.menuButtonRoot }}
+      className={classes.button}
+      color="primary"
+      size="medium"
+      variant="contained"
       onClick={showEnSavoirPlusPopin}>
       <MenuIcon fontSize="small" />
       &nbsp;Info

--- a/components/app-header/tests/__snapshots__/login-button.test.jsx.snap
+++ b/components/app-header/tests/__snapshots__/login-button.test.jsx.snap
@@ -2,11 +2,8 @@
 
 exports[`components | app-header | index snapshot doit correspondre au snapshot existant 1`] = `
 <WithStyles(Button)
-  className="LoginButton-button-2"
-  color="primary"
+  className="LoginButton-menuButtonRoot-2"
   onClick={[Function]}
-  size="medium"
-  variant="contained"
 >
   <pure(VpnKeyIcon)
     classes={

--- a/components/app-header/tests/__snapshots__/menu-button.test.jsx.snap
+++ b/components/app-header/tests/__snapshots__/menu-button.test.jsx.snap
@@ -2,12 +2,11 @@
 
 exports[`components | app-header | index snapshot doit correspondre au snapshot existant 1`] = `
 <WithStyles(Button)
-  classes={
-    Object {
-      "root": "HeaderMenuButton-menuButtonRoot-1",
-    }
-  }
+  className="HeaderMenuButton-button-1"
+  color="primary"
   onClick={[MockFunction]}
+  size="medium"
+  variant="contained"
 >
   <pure(MenuIcon)
     fontSize="small"

--- a/components/reformeur/reformeur-component.module.scss
+++ b/components/reformeur/reformeur-component.module.scss
@@ -9,7 +9,7 @@
   overflow-y: scroll;
   margin-left: 1em;
   padding-right: 10px;
-  width: 600px;
+  width: 530px;
   padding-top: 1em;
 }
 


### PR DESCRIPTION
Suite à une discussion avec @DorineLam et au constat que le bouton "se déconnecter" était bien trop visible, cette PR intervertit le style des deux boutons.

La PR réduit aussi la largeur des articles pour faciliter la lecture sur un écran Mac de 13 pouces.