### PR TITLE
Régler les derniers problèmes d'UI sur les panneaux d'expansion

### DIFF
--- a/components/articles/articles-component.jsx
+++ b/components/articles/articles-component.jsx
@@ -159,8 +159,9 @@ class ArticlesComponent extends React.Component {
             title="Barème"
           >
             <br />
-            <ExpandableText caption="I. En ce qui concerne les contribuables">
-              I. En ce qui concerne les contribuables
+            I. En ce qui concerne les contribuables
+            {" "}
+            <ExpandableText>
               visés à l&apos;article 4 B, il est fait application des règles
               suivantes pour le calcul de l&apos;impôt sur le revenu :
             </ExpandableText>

--- a/components/expandable-panels/ExpandableText.module.scss
+++ b/components/expandable-panels/ExpandableText.module.scss
@@ -5,4 +5,8 @@
     font-size: 14px;
     cursor: pointer;
   }
+
+  svg {
+    vertical-align: middle;
+  }
 }

--- a/components/expandable-panels/ExpandableText.module.scss
+++ b/components/expandable-panels/ExpandableText.module.scss
@@ -1,5 +1,5 @@
 .text {
-  color: grey;
+  color: #696969;
 
   :last-child {
     font-size: 14px;

--- a/components/expandable-panels/ExpandableText.tsx
+++ b/components/expandable-panels/ExpandableText.tsx
@@ -44,7 +44,7 @@ export class ExpandableText extends PureComponent<Props, State> {
               onClick={this.reduce}
               onKeyDown={e => e.key === "Enter" && this.reduce()}>
               {" "}
-              [... lire moins
+              [ lire moins
               {" "}
               <RemoveCircleOutlineIcon />
               {" "}


### PR DESCRIPTION
- [x] Enlever les `...` de `lire moins`.
- [x] Centrer les icônes `+` et `-`.
- [x] Mettre le bon texte visible.

Trello : https://trello.com/c/BNYhhxw5/287-ui-dev-des-contenus-cach%C3%A9s-car-de-moindre-importance

**Avant :**
<img width="468" alt="Capture d’écran 2020-07-01 à 16 19 36" src="https://user-images.githubusercontent.com/13604533/86255434-6409e200-bbb7-11ea-9acd-bd2ab2055e64.png">
<img width="480" alt="Capture d’écran 2020-07-01 à 16 19 30" src="https://user-images.githubusercontent.com/13604533/86255442-666c3c00-bbb7-11ea-8e3d-ce25a914b459.png">

**Après :**
<img width="489" alt="Capture d’écran 2020-07-01 à 16 19 19" src="https://user-images.githubusercontent.com/13604533/86255477-73892b00-bbb7-11ea-9a64-25d6a85ab4e6.png">
<img width="484" alt="Capture d’écran 2020-07-01 à 16 19 11" src="https://user-images.githubusercontent.com/13604533/86255487-7552ee80-bbb7-11ea-8fda-72169043e471.png">
