### PR TITLE
Corrige espacement et chevauchement dans les CGU

### DIFF
--- a/components/en-savoir-plus/EnSavoirPlus.jsx
+++ b/components/en-savoir-plus/EnSavoirPlus.jsx
@@ -79,9 +79,9 @@ class EnSavoirPlus extends PureComponent {
               tous ; les mesures d&apos;impacts sur la population
               française et les recettes de l&apos;État sont disponibles en accès restreint.
             </p>
-            <a className={classes.alink} href="/presentation-et-cgu">
+            <Link className={classes.alink} href="/presentation-et-cgu">
               en savoir plus
-            </a>
+            </Link>
           </Grid>
           <Grid item className={classes.gridItemButtons} xs={6}>
             <div>

--- a/components/en-savoir-plus/EnSavoirPlus.jsx
+++ b/components/en-savoir-plus/EnSavoirPlus.jsx
@@ -79,7 +79,7 @@ class EnSavoirPlus extends PureComponent {
               tous ; les mesures d&apos;impacts sur la population
               française et les recettes de l&apos;État sont disponibles en accès restreint.
             </p>
-            <Link className={classes.alink} href="/presentation-et-cgu">
+            <Link href="/presentation-et-cgu">
               en savoir plus
             </Link>
           </Grid>

--- a/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
+++ b/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
@@ -67,8 +67,8 @@ function TextePresentationLeximpactPop({ classes }) {
 
       <p>
         Les paramètres modifiables dans l&apos;Article 197 du
-        <abbr title="Code général des impôts">CGI</abbr>
-        sont :
+        &nbsp;<abbr title="Code général des impôts">CGI</abbr>
+        &nbsp;sont :
       </p>
       <ul>
         <li>le barème de l&apos;impôt sur le revenu,</li>

--- a/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
+++ b/components/presentation-cgu/texte-presentation-leximpact-pop.jsx
@@ -67,7 +67,8 @@ function TextePresentationLeximpactPop({ classes }) {
 
       <p>
         Les paramètres modifiables dans l&apos;Article 197 du
-        &nbsp;<abbr title="Code général des impôts">CGI</abbr>
+        &nbsp;
+        <abbr title="Code général des impôts">CGI</abbr>
         &nbsp;sont :
       </p>
       <ul>

--- a/components/presentation-cgu/texte-presentation-open-leximpact.jsx
+++ b/components/presentation-cgu/texte-presentation-open-leximpact.jsx
@@ -50,7 +50,8 @@ function TextePresentationOpenLeximpact({ classes }) {
 
       <p>
         Les paramètres modifiables dans l&apos;Article 197 du
-        &nbsp;<abbr title="Code général des impôts">CGI</abbr>
+        &nbsp;
+        <abbr title="Code général des impôts">CGI</abbr>
         &nbsp;sont :
       </p>
       <ul>

--- a/components/presentation-cgu/texte-presentation-open-leximpact.jsx
+++ b/components/presentation-cgu/texte-presentation-open-leximpact.jsx
@@ -50,8 +50,8 @@ function TextePresentationOpenLeximpact({ classes }) {
 
       <p>
         Les paramètres modifiables dans l&apos;Article 197 du
-        <abbr title="Code général des impôts">CGI</abbr>
-        sont :
+        &nbsp;<abbr title="Code général des impôts">CGI</abbr>
+        &nbsp;sont :
       </p>
       <ul>
         <li>le barème de l&apos;impôt sur le revenu,</li>


### PR DESCRIPTION
* À la page [/presentation-et-cgu](https://leximpact.an.fr/presentation-et-cgu), corrige ce bug d'espacement : 

![Screen Shot 2020-07-07 at 11 34 28](https://user-images.githubusercontent.com/6567910/86761103-04dc1f80-c046-11ea-8a0d-c679f5e00203.png)

* Et traite d'une partie du bug de chevauchement des zones de texte des CGU remonté par @thbz (merci !) : l'affichage de la page `/presentation-et-cgu` ne varie désormais plus, qu'on y accède via le lien `en savoir plus` ou le bouton `PRÉSENTATION ET CONDITIONS D'UTILISATION` du menu `INFO`. 
Néanmoins : 
  * Cela affecte le style du lien `en savoir plus` qui était grisé et devient bleu. Après vérification, tous les autres liens des CGU sont bleus. @DorineLam souhaitons-nous toujours avoir un cas particulier de coloration du lien ici ?
  * Cela ne corrige pas entièrement le bug de chevauchement : il est toujours présent en cas de rechargement de la page `/presentation-et-cgu`. @LoicPoullain Aurais-tu une idée de la source de ce comportement ? 🤔 
  