### PR TITLE
[DSR] Permettre l'édition des plafonnements population dans la fraction bourg-centre

### DIFF
--- a/components/common/articles-inputs/values/ParameterValues.tsx
+++ b/components/common/articles-inputs/values/ParameterValues.tsx
@@ -31,6 +31,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>
 
 type Props = PropsFromRedux & {
   editable?: boolean;
+  offset?: number;
   path: string;
   plfTitle?: string|JSX.Element;
   amendementInputSize?: "small"|"xl";

--- a/components/common/articles-inputs/values/Values.tsx
+++ b/components/common/articles-inputs/values/Values.tsx
@@ -36,6 +36,7 @@ interface Props {
   decimals?: number;
   editable?: boolean,
   onAmendementChange?: (value: number) => void,
+  offset?: number;
   plfTitle?: string|JSX.Element|null;
   plfValue?: number|null;
 }
@@ -81,6 +82,12 @@ class Values extends PureComponent<Props & PropsFromRedux> {
       amendementInputSize, amendementTitle, amendementValue, baseValue,
       decimals, editable, onAmendementChange, plfTitle, plfValue,
     } = this.props;
+
+    let { offset } = this.props;
+    if (offset === undefined) {
+      offset = 0;
+    }
+
     const equal = baseValue === amendementValue;
 
     function isDefined(value: number|null|undefined): value is number {
@@ -98,7 +105,9 @@ class Values extends PureComponent<Props & PropsFromRedux> {
           isDefined(plfValue) && withTooltip(
             PlfTooltip,
             plfTitle,
-            <span className={styles.plfValue}>{formatNumber(plfValue, { decimals })}</span>,
+            <span className={styles.plfValue}>
+              {formatNumber(plfValue + offset, { decimals })}
+            </span>,
           )
         }
         {
@@ -112,7 +121,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
               [styles.baseValue]: true,
               [styles.crossedOut]: amendementValue !== undefined,
             })}>
-              {formatNumber(baseValue, { decimals })}
+              {formatNumber(baseValue + offset, { decimals })}
             </span>
           )
         }
@@ -130,8 +139,11 @@ class Values extends PureComponent<Props & PropsFromRedux> {
                   [styles.smallInput]: amendementInputSize === "small",
                   [styles.xlInput]: amendementInputSize === "xl",
                 })}
-                value={amendementValue}
-                onChange={onAmendementChange || (() => {})}
+                value={amendementValue + offset}
+                onChange={onAmendementChange
+                  ? value => onAmendementChange(value - (offset as number))
+                  : (() => {})
+                }
                 onEnter={this.runSimulation} />
             )
             : (
@@ -139,7 +151,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
                 [styles.amendementValue]: true,
                 [styles.amendementValueModified]: !equal,
               })}>
-                {formatNumber(amendementValue, { decimals })}
+                {formatNumber(amendementValue + offset, { decimals })}
               </span>
             ))
         }

--- a/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
+++ b/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
@@ -5,14 +5,12 @@ import { connect, ConnectedProps } from "react-redux";
 // eslint-disable-next-line no-unused-vars
 import { RootState } from "../../../../redux/reducers";
 import {
-  ExpandablePanelSubTitle, ExpandableText, formatNumber, ParameterValues,
+  ExpandablePanelSubTitle, ExpandableText, ParameterValues,
 } from "../../../common";
 import styles from "./DsrFractionBourgCentre.module.scss";
 
 const mapStateToProps = ({ parameters }: RootState) => ({
-  amendementPlafonnementPopulation: parameters.amendement.dotations
-    .communes.dsr.bourgCentre.attribution.plafonnementPopulation,
-  basePlafonnementPopulation: parameters.base.dotations
+  plafonnementPopulation: parameters.amendement.dotations
     .communes.dsr.bourgCentre.attribution.plafonnementPopulation,
 });
 
@@ -22,7 +20,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
   render() {
-    const { amendementPlafonnementPopulation, basePlafonnementPopulation } = this.props;
+    const { plafonnementPopulation } = this.props;
     // Article L2334-21 du CGCT
     return (
       <Fragment>
@@ -225,7 +223,7 @@ class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
         <br />
         <div className={styles.list1}>
           {
-            amendementPlafonnementPopulation.map((_, index) => {
+            plafonnementPopulation.map((_, index) => {
               if (index === 0) {
                 return (
                   <Fragment>
@@ -268,22 +266,15 @@ class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
                   {" "}
                   et
                   {" "}
-                  <span className={styles.bold}>
-                    {formatNumber(basePlafonnementPopulation[index].popMax - 1)}
-                    {" "}
-                    [
-                    {" "}
-                    <ParameterValues
-                      editable
-                      path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.popMax`}
-                    />
-                    {" "}
-                    exclu ]
-                  </span>
+                  <ParameterValues
+                    editable
+                    offset={-1}
+                    path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.popMax`}
+                  />
                   {" "}
                   habitants
                   {
-                    index !== amendementPlafonnementPopulation.length - 1 ? (
+                    index !== plafonnementPopulation.length - 1 ? (
                       <Fragment>
                         {" "}
                         ;

--- a/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
+++ b/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
@@ -1,10 +1,28 @@
 import { Fragment, PureComponent } from "react";
+// eslint-disable-next-line no-unused-vars
+import { connect, ConnectedProps } from "react-redux";
 
-import { ExpandablePanelSubTitle, ExpandableText, ParameterValues } from "../../../common";
+// eslint-disable-next-line no-unused-vars
+import { RootState } from "../../../../redux/reducers";
+import {
+  ExpandablePanelSubTitle, ExpandableText, formatNumber, ParameterValues,
+} from "../../../common";
 import styles from "./DsrFractionBourgCentre.module.scss";
 
-export class DsrFractionBourgCentre extends PureComponent {
+const mapStateToProps = ({ parameters }: RootState) => ({
+  amendementPlafonnementPopulation: parameters.amendement.dotations
+    .communes.dsr.bourgCentre.attribution.plafonnementPopulation,
+  basePlafonnementPopulation: parameters.base.dotations
+    .communes.dsr.bourgCentre.attribution.plafonnementPopulation,
+});
+
+const connector = connect(mapStateToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
   render() {
+    const { amendementPlafonnementPopulation, basePlafonnementPopulation } = this.props;
     // Article L2334-21 du CGCT
     return (
       <Fragment>
@@ -206,16 +224,78 @@ export class DsrFractionBourgCentre extends PureComponent {
         <br />
         <br />
         <div className={styles.list1}>
-        – plafonnée à 500 habitants pour les communes dont la population issue du dernier
-        recensement est inférieure à 100 habitants ;
-          <br />
-          <br />
-        – plafonnée à 1 000 habitants pour les communes dont la population issue du dernier
-        recensement est comprise entre 100 et 499 habitants ;
-          <br />
-          <br />
-        – plafonnée à 2 250 habitants pour les communes dont la population issue du dernier
-        recensement est comprise entre 500 et 1 499 habitants.
+          {
+            amendementPlafonnementPopulation.map((_, index) => {
+              if (index === 0) {
+                return (
+                  <Fragment>
+                    – plafonnée à
+                    {" "}
+                    <ParameterValues
+                      editable
+                      path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.plafonnement`}
+                    />
+                    {" "}
+                    habitants pour les communes dont la population issue du dernier
+                    recensement est inférieure à
+                    {" "}
+                    <ParameterValues
+                      editable
+                      path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.popMax`}
+                    />
+                    {" "}
+                    habitants ;
+                    <br />
+                    <br />
+                  </Fragment>
+                );
+              }
+              return (
+                <Fragment>
+                  – plafonnée à
+                  {" "}
+                  <ParameterValues
+                    editable
+                    path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.plafonnement`}
+                  />
+                  {" "}
+                  habitants pour les communes dont la population issue du dernier
+                  recensement est comprise entre
+                  {" "}
+                  <ParameterValues
+                    path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index - 1}.popMax`}
+                  />
+                  {" "}
+                  et
+                  {" "}
+                  <span className={styles.bold}>
+                    {formatNumber(basePlafonnementPopulation[index].popMax - 1)}
+                    {" "}
+                    [
+                    {" "}
+                    <ParameterValues
+                      editable
+                      path={`dotations.communes.dsr.bourgCentre.attribution.plafonnementPopulation.${index}.popMax`}
+                    />
+                    {" "}
+                    exclu ]
+                  </span>
+                  {" "}
+                  habitants
+                  {
+                    index !== amendementPlafonnementPopulation.length - 1 ? (
+                      <Fragment>
+                        {" "}
+                        ;
+                        <br />
+                        <br />
+                      </Fragment>
+                    ) : "."
+                  }
+                </Fragment>
+              );
+            })
+          }
         </div>
         <br />
         Ce plafond s&apos;applique uniquement à la population de la commune concernée et
@@ -224,3 +304,7 @@ export class DsrFractionBourgCentre extends PureComponent {
     );
   }
 }
+
+const ConnectedDsrFractionBourgCentre = connector(DsrFractionBourgCentre);
+
+export { ConnectedDsrFractionBourgCentre as DsrFractionBourgCentre };

--- a/redux/reducers/parameters/base/dotations.ts
+++ b/redux/reducers/parameters/base/dotations.ts
@@ -39,11 +39,11 @@ export const BASE_DOTATIONS_DEFAULT_STATE: DotationsState = {
           coefMultiplicateurRevitalisationRurale: 1.3,
           // pourcentageAttributionMin: 90,
           // pourcentageAttributionMax: 120,
-          // plafonnementPopulation: {
-          //   500: 100,
-          //   1000: 500,
-          //   2250: 1500,
-          // },
+          plafonnementPopulation: [
+            { plafonnement: 500, popMax: 100 },
+            { plafonnement: 1000, popMax: 500 },
+            { plafonnement: 2250, popMax: 1500 },
+          ],
         },
       },
       // Article L2334-22 du CGCT

--- a/redux/reducers/parameters/interfaces/dotations-state.ts
+++ b/redux/reducers/parameters/interfaces/dotations-state.ts
@@ -34,9 +34,10 @@ export interface DotationsState {
           coefMultiplicateurRevitalisationRurale: number;
           // pourcentageAttributionMin: number;
           // pourcentageAttributionMax: number;
-          // plafonnementPopulation: {
-          //   [recensement: number]: number;
-          // }
+          plafonnementPopulation: {
+            popMax: number;
+            plafonnement: number;
+          }[]
         }
       }
       // Article L2334-22 du CGCT

--- a/redux/reducers/parameters/plf/dotations.ts
+++ b/redux/reducers/parameters/plf/dotations.ts
@@ -39,11 +39,11 @@ export const PLF_DOTATIONS_DEFAULT_STATE: DotationsState = {
           coefMultiplicateurRevitalisationRurale: 1.3,
           // pourcentageAttributionMin: 90,
           // pourcentageAttributionMax: 120,
-          // plafonnementPopulation: {
-          //   500: 100,
-          //   1000: 500,
-          //   2250: 1500,
-          // },
+          plafonnementPopulation: [
+            { plafonnement: 500, popMax: 100 },
+            { plafonnement: 1000, popMax: 500 },
+            { plafonnement: 2250, popMax: 1500 },
+          ],
         },
       },
       // Article L2334-22 du CGCT


### PR DESCRIPTION
https://trello.com/c/I9wrPBTt/384-dsr-ajouter-les-param%C3%A8tres-%C3%A9ditables-manquants

L'ajout ou la suppression de nouvelles strates n'est pas disponible dans cette PR.

@DorineLam peux-tu vérifier le design ?
@magemax peux-tu vérifier que le contenu `plafonnementPopulation` que je t'envoie est correct ? Je n'arrive pas à voir de changements avec le simulateur.