### PR TITLE
Modify the architecture of texte "répartition DSU"

### DIFF
--- a/components/dotations/articles/dsu-repartition/DsuRepartition.tsx
+++ b/components/dotations/articles/dsu-repartition/DsuRepartition.tsx
@@ -8,8 +8,9 @@ export class DsuRepartition extends PureComponent {
     // Article L2334-20 du CGCT
     return (
       <Fragment>
-        <ExpandablePanelSubTitle subTitle="Articles L2334-18-2 §4 et L2334-18-4" title="Communes déjà éligibles" />
-        À compter de 2017, les communes éligibles au titre de&nbsp;
+        <ExpandablePanelSubTitle subTitle="Articles L2334-18-2 § 4 et L2334-18-4" title="Communes déjà éligibles" />
+        À compter de 2017, les communes éligibles au titre de
+        {" "}
         <a
           href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
           rel="noopener noreferrer"
@@ -17,9 +18,10 @@ export class DsuRepartition extends PureComponent {
         >
           l&apos;article L. 2334-16
         </a>
-        &nbsp;
+        {" "}
         perçoivent une dotation égale à celle perçue
-        l&apos;année précédente, majorée de l&apos;augmentation prévue à&nbsp;
+        l&apos;année précédente, majorée de l&apos;augmentation prévue à
+        {" "}
         <a
           href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814522&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
           rel="noopener noreferrer"
@@ -27,7 +29,8 @@ export class DsuRepartition extends PureComponent {
         >
           l&apos;article L. 2334-18-4
         </a>
-        .&nbsp;
+        .
+        {" "}
         <ExpandableText caption="Suite sur les communes nouvellement éligibles">
           Les communes qui n&apos;étaient pas éligibles
           à la dotation l&apos;année précédant l&apos;année de versement bénéficient
@@ -36,7 +39,8 @@ export class DsuRepartition extends PureComponent {
         <br />
         <br />
          L&apos;augmentation de la dotation, après répartition des attributions
-         calculées en application des articles&nbsp;
+         calculées en application des articles
+        {" "}
         <a
           href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
           rel="noopener noreferrer"
@@ -44,7 +48,9 @@ export class DsuRepartition extends PureComponent {
         >
           L. 2334-16
         </a>
-        &nbsp;à&nbsp;
+        {" "}
+        à
+        {" "}
         <a
           href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814534&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
           rel="noopener noreferrer"
@@ -58,7 +64,8 @@ export class DsuRepartition extends PureComponent {
         <br />
         <br />
         La part d&apos;augmentation est répartie entre les communes bénéficiaires
-        dans les conditions prévues aux deux premiers alinéas de&nbsp;
+        dans les conditions prévues aux deux premiers alinéas de
+        {" "}
         <a
           href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814543&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
           rel="noopener noreferrer"

--- a/components/dotations/articles/dsu-repartition/DsuRepartition.tsx
+++ b/components/dotations/articles/dsu-repartition/DsuRepartition.tsx
@@ -1,6 +1,6 @@
 import { Fragment, PureComponent } from "react";
 
-import { ExpandablePanelSubTitle, ParameterValues } from "../../../common";
+import { ExpandablePanelSubTitle, ExpandableText, ParameterValues } from "../../../common";
 import styles from "./DsuRepartition.module.scss";
 
 export class DsuRepartition extends PureComponent {
@@ -8,10 +8,73 @@ export class DsuRepartition extends PureComponent {
     // Article L2334-20 du CGCT
     return (
       <Fragment>
-        <ExpandablePanelSubTitle subTitle="Article L2334-18-2" title="Règle générale" />
+        <ExpandablePanelSubTitle subTitle="Articles L2334-18-2 §4 et L2334-18-4" title="Communes déjà éligibles" />
+        À compter de 2017, les communes éligibles au titre de&nbsp;
+        <a
+          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          l&apos;article L. 2334-16
+        </a>
+        &nbsp;
+        perçoivent une dotation égale à celle perçue
+        l&apos;année précédente, majorée de l&apos;augmentation prévue à&nbsp;
+        <a
+          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814522&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          l&apos;article L. 2334-18-4
+        </a>
+        .&nbsp;
+        <ExpandableText caption="Suite sur les communes nouvellement éligibles">
+          Les communes qui n&apos;étaient pas éligibles
+          à la dotation l&apos;année précédant l&apos;année de versement bénéficient
+          d&apos;une attribution calculée en application du présent article.
+        </ExpandableText>
+        <br />
+        <br />
+         L&apos;augmentation de la dotation, après répartition des attributions
+         calculées en application des articles&nbsp;
+        <a
+          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          L. 2334-16
+        </a>
+        &nbsp;à&nbsp;
+        <a
+          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814534&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          L. 2334-18-3
+        </a>
+        ,
+         est répartie entre les deux catégories démographiques
+         au prorata de leur population dans le total des communes bénéficiaires.
+        <br />
+        <br />
+        La part d&apos;augmentation est répartie entre les communes bénéficiaires
+        dans les conditions prévues aux deux premiers alinéas de&nbsp;
+        <a
+          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814543&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          l&apos;article L. 2334-18-2
+        </a>
+        .
+        Les communes qui n&apos;étaient pas éligibles à la dotation
+        l&apos;année précédant la répartition ne bénéficient pas de cette part.
+        <br />
+        <br />
+        <ExpandablePanelSubTitle subTitle="Article L2334-18-2 § 1 et 2" title="Communes nouvellement éligibles" />
         La dotation revenant à chaque commune éligible est égale au produit
-         de sa population par la valeur de l&apos;indice qui lui est attribué.
-         Ce produit est pondéré par l&apos;effort fiscal dans la limite de
+        de sa population par la valeur de l&apos;indice qui lui est attribué.
+        Ce produit est pondéré par l&apos;effort fiscal dans la limite de
         {" "}
         <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.attribution.effortFiscalLimite" />
         {" "}
@@ -59,69 +122,12 @@ export class DsuRepartition extends PureComponent {
         population dans les zones existant au 1er janvier 2014.
         <br />
         <br />
+        <ExpandablePanelSubTitle subTitle="Article L2334-18-2 § 3" title="Toutes communes" />
         L&apos;accroissement de la dotation de chaque commune ne peut excéder
         4 millions d&apos;euros par an.
         <br />
         <br />
-        À compter de 2017, les communes éligibles au titre de&nbsp;
-        <a
-          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          l&apos;article L. 2334-16
-        </a>
-        &nbsp;
-        perçoivent une dotation égale à celle perçue
-        l&apos;année précédente, majorée de l&apos;augmentation prévue à&nbsp;
-        <a
-          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814522&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          l&apos;article L. 2334-18-4
-        </a>
-        .
-        Les communes qui n&apos;étaient pas éligibles
-         à la dotation l&apos;année précédant l&apos;année de versement bénéficient
-         d&apos;une attribution calculée en application du présent article.
-        <br />
-        <br />
-        <ExpandablePanelSubTitle subTitle="Article L2334-18-4" title="Règle en cas d&apos;augmentation de la dotation" />
-         L&apos;augmentation de la dotation, après répartition des attributions
-         calculées en application des articles&nbsp;
-        <a
-          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814578&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          L. 2334-16
-        </a>
-        &nbsp;à&nbsp;
-        <a
-          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814534&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          L. 2334-18-3
-        </a>
-        ,
-         est répartie entre les deux catégories démographiques
-         au prorata de leur population dans le total des communes bénéficiaires.
-        <br />
-        <br />
-        La part d&apos;augmentation est répartie entre les communes bénéficiaires
-        dans les conditions prévues aux deux premiers alinéas de&nbsp;
-        <a
-          href="https://www.legifrance.gouv.fr/affichCodeArticle.do;jsessionid=77D4545E5B93968FCA804A193A0C9A54.tplgfr38s_3?idArticle=LEGIARTI000033814543&cidTexte=LEGITEXT000006070633&dateTexte=20170101"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          l&apos;article L. 2334-18-2
-        </a>
-        .
-        Les communes qui n&apos;étaient pas éligibles à la dotation
-        l&apos;année précédant la répartition ne bénéficient pas de cette part.
+
       </Fragment>
     );
   }


### PR DESCRIPTION
J'ai recomposé le texte pour différencier 3 parties différentes de la répartition : 

- les règles concernant les communes déjà éligibles ;
- les règles concernant les communes nouvellement éligibles;
- les règles concernant toutes les communes.

Cela devrait permettre de mieux comprendre le sens de ce texte, mais présente aussi le défaut de désorganiser l'ordre de la loi existante.