### PR TITLE
Ajouter l'option recherche de communes

### DIFF
--- a/components/common/card/Card.tsx
+++ b/components/common/card/Card.tsx
@@ -13,7 +13,7 @@ interface Props {
   subTitle?: string;
   onClose?: () => void;
   onEdit?: () => void;
-  content1: JSX.Element;
+  content1?: JSX.Element;
   content2?: JSX.Element | null;
   content3?: JSX.Element | null;
 }
@@ -21,7 +21,7 @@ interface Props {
 export class Card extends PureComponent<Props> {
   render() {
     const {
-      colored, content1, content2, content3, icon, onClose, onEdit, subTitle, title,
+      children, colored, content1, content2, content3, icon, onClose, onEdit, subTitle, title,
     } = this.props;
     return (
       <div className={styles.card}>
@@ -49,7 +49,7 @@ export class Card extends PureComponent<Props> {
           [styles.content1]: true,
           [styles.colored]: !!colored,
         })}>
-          {content1}
+          {content1 || children}
         </div>
         {content2 && <Divider />}
         {content2 && (

--- a/components/dotations/results/Results.tsx
+++ b/components/dotations/results/Results.tsx
@@ -5,7 +5,7 @@ import { connect, ConnectedProps } from "react-redux";
 
 // eslint-disable-next-line no-unused-vars
 import { RootState } from "../../../redux/reducers";
-// import { CommuneSearch } from "./commune-search";
+import { CommuneSearch } from "./commune-search";
 import { CommuneStrateDetails } from "./commune-strate-details";
 import { CommuneSummary } from "./commune-summary";
 import { CommuneType } from "./commune-type";
@@ -54,9 +54,9 @@ class Results extends PureComponent<Props> {
               />
             </Grid>
           ))}
-          {/* <Grid item lg={4} md={6} sm={6} xl={3} xs={12}>
+          <Grid item lg={4} md={6} sm={6} xl={3} xs={12}>
             <CommuneSearch />
-          </Grid> */}
+          </Grid>
         </Grid>
       </div>
     );

--- a/components/dotations/results/Results.tsx
+++ b/components/dotations/results/Results.tsx
@@ -26,6 +26,7 @@ class Results extends PureComponent<Props> {
     const { communesTypes } = this.props;
     const url = new URLSearchParams(window.location.search);
     const isDsuVisible = url.has("dsu");
+    const isSearchVisible = url.has("search");
     return (
       <div className={styles.container}>
         <Grid container spacing={3}>
@@ -54,9 +55,11 @@ class Results extends PureComponent<Props> {
               />
             </Grid>
           ))}
-          <Grid item lg={4} md={6} sm={6} xl={3} xs={12}>
-            <CommuneSearch />
-          </Grid>
+          {isSearchVisible && (
+            <Grid item lg={4} md={6} sm={6} xl={3} xs={12}>
+              <CommuneSearch />
+            </Grid>
+          )}
         </Grid>
       </div>
     );

--- a/components/dotations/results/commune-search/CommuneSearch.tsx
+++ b/components/dotations/results/commune-search/CommuneSearch.tsx
@@ -2,12 +2,17 @@ import { PureComponent } from "react";
 // eslint-disable-next-line no-unused-vars
 import { connect, ConnectedProps } from "react-redux";
 
+import { addCommuneType } from "../../../../redux/actions";
+// eslint-disable-next-line no-unused-vars
+import { Commune } from "../../../../redux/reducers/descriptions/dotations";
 import { Card } from "../../../common";
 import { SearchInput } from "./search-input";
 
 const mapStateToProps = () => ({});
 
-const mapDispatchToProps = dispatch => ({});
+const mapDispatchToProps = dispatch => ({
+  add: (commune: Commune) => dispatch(addCommuneType(commune)),
+});
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
@@ -15,12 +20,13 @@ type PropsFromRedux = ConnectedProps<typeof connector>
 
 class CommuneSearch extends PureComponent<PropsFromRedux> {
   render() {
+    const { add } = this.props;
     return (
       <Card
         title="Ajouter une nouvelle commune"
       >
         <div>
-          <SearchInput onChange={commune => console.log(commune)} />
+          <SearchInput onChange={commune => add(commune)} />
         </div>
       </Card>
     );

--- a/components/dotations/results/commune-search/CommuneSearch.tsx
+++ b/components/dotations/results/commune-search/CommuneSearch.tsx
@@ -1,15 +1,32 @@
 import { PureComponent } from "react";
+// eslint-disable-next-line no-unused-vars
+import { connect, ConnectedProps } from "react-redux";
 
 import { Card } from "../../../common";
 import { SearchInput } from "./search-input";
 
-export class CommuneSearch extends PureComponent {
+const mapStateToProps = () => ({});
+
+const mapDispatchToProps = dispatch => ({});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>
+
+class CommuneSearch extends PureComponent<PropsFromRedux> {
   render() {
     return (
       <Card
-        content1={<SearchInput />}
         title="Ajouter une nouvelle commune"
-      />
+      >
+        <div>
+          <SearchInput onChange={commune => console.log(commune)} />
+        </div>
+      </Card>
     );
   }
 }
+
+const Component = connector(CommuneSearch);
+
+export { Component as CommuneSearch };

--- a/components/dotations/results/commune-search/search-input/SearchInput.tsx
+++ b/components/dotations/results/commune-search/search-input/SearchInput.tsx
@@ -8,6 +8,7 @@ import { PureComponent } from "react";
 
 // eslint-disable-next-line no-unused-vars
 import { Commune } from "../../../../../redux/reducers/descriptions/dotations";
+// import request from "../../../../common/utils/request";
 
 function sleep(delay = 0) {
   return new Promise((resolve) => {
@@ -24,6 +25,10 @@ interface State {
   communes: Commune[] | null;
 }
 
+// interface ResponseBody {
+//   communes: Commune[]
+// }
+
 export class SearchInput extends PureComponent<Props, State> {
   constructor(props) {
     super(props);
@@ -34,8 +39,17 @@ export class SearchInput extends PureComponent<Props, State> {
     this.search = debounce(this.search.bind(this), 300);
   }
 
+  // eslint-disable-next-line no-unused-vars
   async search(search: string): Promise<void> {
     this.setState({ communes: null });
+
+    // await request
+    //   .get(`/dotations?search=${encodeURI(search)}`)
+    //   .then(({ communes }: ResponseBody) => {
+    //     this.setState({ communes });
+    //   })
+    //   .catch(() => {});
+
     await sleep(1e3);
     this.setState({
       communes: [

--- a/components/dotations/results/commune-search/search-input/SearchInput.tsx
+++ b/components/dotations/results/commune-search/search-input/SearchInput.tsx
@@ -23,6 +23,7 @@ interface Props {
 interface State {
   open: boolean;
   communes: Commune[] | null;
+  value: Commune | null;
 }
 
 // interface ResponseBody {
@@ -35,6 +36,7 @@ export class SearchInput extends PureComponent<Props, State> {
     this.state = {
       communes: [],
       open: false,
+      value: null,
     };
     this.search = debounce(this.search.bind(this), 300);
   }
@@ -73,7 +75,7 @@ export class SearchInput extends PureComponent<Props, State> {
 
   render() {
     const { onChange } = this.props;
-    const { communes, open } = this.state;
+    const { communes, open, value } = this.state;
     return (
       <Autocomplete
         freeSolo
@@ -99,11 +101,13 @@ export class SearchInput extends PureComponent<Props, State> {
           />
         )}
         style={{ width: "100%" }}
+        value={value}
         onChange={(event: any, commune: Commune | null) => {
           if (commune) {
             onChange(commune);
-            // Reset
-            this.setState({ communes: [] });
+            this.setState({ communes: [], value: commune });
+            // Small hack to clear the input.
+            setTimeout(() => this.setState({ value: null }), 0);
           }
         }}
         onClose={() => this.setState({ open: false })}

--- a/components/dotations/results/commune-search/search-input/SearchInput.tsx
+++ b/components/dotations/results/commune-search/search-input/SearchInput.tsx
@@ -1,9 +1,103 @@
+import CircularProgress from "@material-ui/core/CircularProgress";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import TextField from "@material-ui/core/TextField";
+import SearchIcon from "@material-ui/icons/Search";
+import Autocomplete from "@material-ui/lab/Autocomplete";
+import debounce from "lodash/debounce";
 import { PureComponent } from "react";
 
-export class SearchInput extends PureComponent {
+// eslint-disable-next-line no-unused-vars
+import { Commune } from "../../../../../redux/reducers/descriptions/dotations";
+
+function sleep(delay = 0) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+}
+
+interface Props {
+  onChange: (commune: Commune) => void;
+}
+
+interface State {
+  open: boolean;
+  communes: Commune[] | null;
+}
+
+export class SearchInput extends PureComponent<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      communes: [],
+      open: false,
+    };
+    this.search = debounce(this.search.bind(this), 300);
+  }
+
+  async search(search: string): Promise<void> {
+    this.setState({ communes: null });
+    await sleep(1e3);
+    this.setState({
+      communes: [
+        {
+          code: "76384",
+          departement: "Seine-Maritime",
+          habitants: 9101,
+          name: "Lillebonne",
+          potentielFinancier: 2188.612857,
+        },
+        {
+          code: "76214",
+          departement: "Seine-Maritime",
+          habitants: 262,
+          name: "Dénestanville",
+          potentielFinancier: 706.242647,
+        },
+      ],
+    });
+  }
+
   render() {
+    const { onChange } = this.props;
+    const { communes, open } = this.state;
     return (
-      <div />
+      <Autocomplete
+        freeSolo
+        getOptionLabel={option => `${option.name} (${option.code})`}
+        open={open}
+        options={communes || []}
+        renderInput={params => (
+          <TextField
+            {...params}
+            color="secondary"
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  {communes === null && <CircularProgress color="secondary" size={20} style={{ marginRight: 10 }} />}
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+              ref: params.InputProps.ref,
+            }}
+            label="Nom de la commune"
+            margin="normal"
+            variant="filled"
+          />
+        )}
+        style={{ width: "100%" }}
+        onChange={(event: any, commune: Commune | null) => {
+          if (commune) {
+            onChange(commune);
+            // Reset
+            this.setState({ communes: [] });
+          }
+        }}
+        onClose={() => this.setState({ open: false })}
+        onInputChange={(event, search) => {
+          this.search(search);
+        }}
+        onOpen={() => this.setState({ open: true })}
+      />
     );
   }
 }

--- a/components/dotations/results/commune-search/search-input/SearchInput.tsx
+++ b/components/dotations/results/commune-search/search-input/SearchInput.tsx
@@ -69,6 +69,13 @@ export class SearchInput extends PureComponent<Props, State> {
           name: "Dénestanville",
           potentielFinancier: 706.242647,
         },
+        {
+          code: "77186",
+          departement: "Seine-et-Marne",
+          habitants: 15417,
+          name: "Fontainebleau",
+          potentielFinancier: 1110.296193,
+        },
       ],
     });
   }

--- a/components/dotations/results/commune-type/CommuneType.tsx
+++ b/components/dotations/results/commune-type/CommuneType.tsx
@@ -5,6 +5,7 @@ import { Fragment, PureComponent } from "react";
 // eslint-disable-next-line no-unused-vars
 import { connect, ConnectedProps } from "react-redux";
 
+import { removeCommuneType } from "../../../../redux/actions";
 // eslint-disable-next-line no-unused-vars
 import { RootState } from "../../../../redux/reducers";
 // eslint-disable-next-line no-unused-vars
@@ -24,7 +25,11 @@ const mapStateToProps = ({ results }: RootState) => ({
     || results.plf.dotations.isFetching,
 });
 
-const connector = connect(mapStateToProps);
+const mapDispatchToProps = dispatch => ({
+  remove: (index: number) => dispatch(removeCommuneType(index)),
+});
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>
 
@@ -35,7 +40,7 @@ type Props = PropsFromRedux & Commune & {
 class CommuneType extends PureComponent<Props> {
   render() {
     const {
-      departement, habitants, index, isFetching, name, potentielFinancier,
+      departement, habitants, index, isFetching, name, potentielFinancier, remove,
     } = this.props;
     const url = new URLSearchParams(window.location.search);
     const isDsuVisible = url.has("dsu");
@@ -95,6 +100,7 @@ class CommuneType extends PureComponent<Props> {
             )}
         subTitle={departement}
         title={name}
+        onClose={() => remove(index)}
       />
     );
   }

--- a/components/dotations/results/commune-type/dotation-diff/DotationDiff.tsx
+++ b/components/dotations/results/commune-type/dotation-diff/DotationDiff.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const mapStateToProps = ({ results }: RootState, { dotation, index }: Props) => ({
   diff: results.baseToAmendement.dotations
-    .state?.communes[dotation].communes[index].diffDotationParHab ?? null,
+    .state?.communes[dotation].communes[index]?.diffDotationParHab ?? null,
 });
 
 const connector = connect(mapStateToProps);

--- a/components/dotations/results/commune-type/dotation-trend/DotationTrend.tsx
+++ b/components/dotations/results/commune-type/dotation-trend/DotationTrend.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const mapStateToProps = ({ results }: RootState, { index }: Props) => ({
   diff: results.baseToAmendement.dotations
-    .state?.communes.dgf.communes[index].diffDotationParHab ?? null,
+    .state?.communes.dgf.communes[index]?.diffDotationParHab ?? null,
 });
 
 const connector = connect(mapStateToProps);

--- a/components/ir/articles/quotient-familial/regles-generales/QfTable.tsx
+++ b/components/ir/articles/quotient-familial/regles-generales/QfTable.tsx
@@ -167,6 +167,6 @@ class QfTable extends PureComponent<Props> {
   }
 }
 
-const ConnectedQfTable = connector(QfTable);
+const Component = connector(QfTable);
 
-export { ConnectedQfTable as QfTable };
+export { Component as QfTable };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4165,6 +4165,18 @@
                 "@babel/runtime": "^7.4.4"
             }
         },
+        "@material-ui/lab": {
+            "version": "4.0.0-alpha.56",
+            "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+            "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+            "requires": {
+                "@babel/runtime": "^7.4.4",
+                "@material-ui/utils": "^4.10.2",
+                "clsx": "^1.0.4",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.8.0"
+            }
+        },
         "@material-ui/styles": {
             "version": "4.10.0",
             "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@iconify/react": "^1.1.3",
     "@material-ui/core": "^4.10.2",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",
     "@nivo/bar": "0.59.0",
     "@typescript-eslint/eslint-plugin": "^2.29.0",

--- a/redux/actions/descriptions/add-commune-type.ts
+++ b/redux/actions/descriptions/add-commune-type.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+import { Commune } from "../../reducers/descriptions/dotations";
+
+export interface AddCommuneTypeAction {
+  type: "ADD_COMMUNE_TYPE";
+  commune: Commune;
+}
+
+export function addCommuneType(commune: Commune): AddCommuneTypeAction {
+  return {
+    commune,
+    type: "ADD_COMMUNE_TYPE",
+  };
+}

--- a/redux/actions/descriptions/index.ts
+++ b/redux/actions/descriptions/index.ts
@@ -1,0 +1,2 @@
+export * from "./add-commune-type";
+export * from "./remove-commune-type";

--- a/redux/actions/descriptions/remove-commune-type.ts
+++ b/redux/actions/descriptions/remove-commune-type.ts
@@ -1,0 +1,11 @@
+export interface RemoveCommuneTypeAction {
+  type: "REMOVE_COMMUNE_TYPE";
+  index: number;
+}
+
+export function removeCommuneType(index: number): RemoveCommuneTypeAction {
+  return {
+    index,
+    type: "REMOVE_COMMUNE_TYPE",
+  };
+}

--- a/redux/actions/index.ts
+++ b/redux/actions/index.ts
@@ -1,5 +1,6 @@
 export { default as logOut } from "./log-out";
 export * from "./loading-etat";
+export * from "./descriptions";
 export * from "./display";
 export * from "./parameters";
 export * from "./simulations";

--- a/redux/reducers/descriptions/dotations/communes-types.ts
+++ b/redux/reducers/descriptions/dotations/communes-types.ts
@@ -45,7 +45,9 @@ export function communesTypes(
       action.commune,
     ];
   case "REMOVE_COMMUNE_TYPE":
-    return [...state].splice(action.index, 1);
+    const newState = [...state];
+    newState.splice(action.index, 1);
+    return newState;
   default:
     return state;
   }

--- a/redux/reducers/descriptions/dotations/communes-types.ts
+++ b/redux/reducers/descriptions/dotations/communes-types.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line no-unused-vars
+import { AddCommuneTypeAction, RemoveCommuneTypeAction } from "../../../actions";
+
 export interface Commune {
   code: string;
   name: string;
@@ -30,6 +33,20 @@ const DEFAULT_STATE: Commune[] = [
   },
 ];
 
-export function communesTypes(state: Commune[] = DEFAULT_STATE): Commune[] {
-  return state;
+type CommunesTypesAction = AddCommuneTypeAction | RemoveCommuneTypeAction;
+
+export function communesTypes(
+  state: Commune[] = DEFAULT_STATE, action: CommunesTypesAction,
+): Commune[] {
+  switch (action.type) {
+  case "ADD_COMMUNE_TYPE":
+    return [
+      ...state,
+      action.commune,
+    ];
+  case "REMOVE_COMMUNE_TYPE":
+    return [...state].splice(action.index, 1);
+  default:
+    return state;
+  }
 }

--- a/redux/reducers/descriptions/dotations/communes-types.ts
+++ b/redux/reducers/descriptions/dotations/communes-types.ts
@@ -40,6 +40,9 @@ export function communesTypes(
 ): Commune[] {
   switch (action.type) {
   case "ADD_COMMUNE_TYPE":
+    if (state.find(commune => commune.code === action.commune.code)) {
+      return state;
+    }
     return [
       ...state,
       action.commune,

--- a/redux/reducers/results/amendement/dotations.ts
+++ b/redux/reducers/results/amendement/dotations.ts
@@ -1,12 +1,15 @@
 /* eslint-disable sort-keys */
 import {
   // eslint-disable-next-line no-unused-vars
+  RemoveCommuneTypeAction,
+  // eslint-disable-next-line no-unused-vars
   SimulateDotationsFailureAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsRequestAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsSuccessAction,
 } from "../../../actions";
+import { removeCommuneTypeResults } from "../common";
 // eslint-disable-next-line no-unused-vars
 import { AsyncState, DotationsState } from "../interfaces";
 
@@ -18,7 +21,8 @@ const DEFAULT_STATE: AsyncState<DotationsState> = {
 type DotationsAction =
   SimulateDotationsFailureAction |
   SimulateDotationsRequestAction |
-  SimulateDotationsSuccessAction;
+  SimulateDotationsSuccessAction |
+  RemoveCommuneTypeAction;
 
 export function dotations(
   state: AsyncState<DotationsState> = DEFAULT_STATE, action: DotationsAction,
@@ -38,6 +42,14 @@ export function dotations(
     return {
       isFetching: false,
       state: action.dotations.amendement,
+    };
+  case "REMOVE_COMMUNE_TYPE":
+    if (state.state === null) {
+      return state;
+    }
+    return {
+      isFetching: false,
+      state: removeCommuneTypeResults(state.state, action.index),
     };
   default:
     return state;

--- a/redux/reducers/results/base/dotations.ts
+++ b/redux/reducers/results/base/dotations.ts
@@ -1,12 +1,15 @@
 /* eslint-disable sort-keys */
 import {
   // eslint-disable-next-line no-unused-vars
+  RemoveCommuneTypeAction,
+  // eslint-disable-next-line no-unused-vars
   SimulateDotationsFailureAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsRequestAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsSuccessAction,
 } from "../../../actions";
+import { removeCommuneTypeResults } from "../common";
 // eslint-disable-next-line no-unused-vars
 import { AsyncState, DotationsState } from "../interfaces";
 
@@ -18,7 +21,8 @@ const DEFAULT_STATE: AsyncState<DotationsState> = {
 type DotationsAction =
   SimulateDotationsFailureAction |
   SimulateDotationsRequestAction |
-  SimulateDotationsSuccessAction;
+  SimulateDotationsSuccessAction |
+  RemoveCommuneTypeAction;
 
 export function dotations(
   state: AsyncState<DotationsState> = DEFAULT_STATE, action: DotationsAction,
@@ -38,6 +42,14 @@ export function dotations(
     return {
       isFetching: false,
       state: action.dotations.base,
+    };
+  case "REMOVE_COMMUNE_TYPE":
+    if (state.state === null) {
+      return state;
+    }
+    return {
+      isFetching: false,
+      state: removeCommuneTypeResults(state.state, action.index),
     };
   default:
     return state;

--- a/redux/reducers/results/baseToAmendement/dotations.ts
+++ b/redux/reducers/results/baseToAmendement/dotations.ts
@@ -1,11 +1,14 @@
 import {
   // eslint-disable-next-line no-unused-vars
+  RemoveCommuneTypeAction,
+  // eslint-disable-next-line no-unused-vars
   SimulateDotationsFailureAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsRequestAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsSuccessAction,
 } from "../../../actions";
+import { removeCommuneTypeDiffResults } from "../common";
 // eslint-disable-next-line no-unused-vars
 import { AsyncState, DotationsDiffState } from "../interfaces";
 
@@ -17,7 +20,8 @@ const DEFAULT_STATE: AsyncState<DotationsDiffState> = {
 type DotationsAction =
   SimulateDotationsFailureAction |
   SimulateDotationsRequestAction |
-  SimulateDotationsSuccessAction;
+  SimulateDotationsSuccessAction |
+  RemoveCommuneTypeAction;
 
 export function dotations(
   state: AsyncState<DotationsDiffState> = DEFAULT_STATE, action: DotationsAction,
@@ -83,6 +87,14 @@ export function dotations(
           dsu,
         },
       },
+    };
+  case "REMOVE_COMMUNE_TYPE":
+    if (state.state === null) {
+      return state;
+    }
+    return {
+      isFetching: false,
+      state: removeCommuneTypeDiffResults(state.state, action.index),
     };
   default:
     return state;

--- a/redux/reducers/results/baseToPlf/dotations.ts
+++ b/redux/reducers/results/baseToPlf/dotations.ts
@@ -1,11 +1,14 @@
 import {
   // eslint-disable-next-line no-unused-vars
+  RemoveCommuneTypeAction,
+  // eslint-disable-next-line no-unused-vars
   SimulateDotationsFailureAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsRequestAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsSuccessAction,
 } from "../../../actions";
+import { removeCommuneTypeDiffResults } from "../common";
 // eslint-disable-next-line no-unused-vars
 import { AsyncState, DotationsDiffState } from "../interfaces";
 
@@ -17,7 +20,8 @@ const DEFAULT_STATE: AsyncState<DotationsDiffState> = {
 type DotationsAction =
   SimulateDotationsFailureAction |
   SimulateDotationsRequestAction |
-  SimulateDotationsSuccessAction;
+  SimulateDotationsSuccessAction |
+  RemoveCommuneTypeAction;
 
 export function dotations(
   state: AsyncState<DotationsDiffState> = DEFAULT_STATE, action: DotationsAction,
@@ -107,6 +111,14 @@ export function dotations(
           dsu,
         },
       },
+    };
+  case "REMOVE_COMMUNE_TYPE":
+    if (state.state === null) {
+      return state;
+    }
+    return {
+      isFetching: false,
+      state: removeCommuneTypeDiffResults(state.state, action.index),
     };
   default:
     return state;

--- a/redux/reducers/results/common/index.ts
+++ b/redux/reducers/results/common/index.ts
@@ -1,0 +1,2 @@
+export * from "./remove-commune-type-results";
+export * from "./remove-commune-type-diff-results";

--- a/redux/reducers/results/common/remove-commune-type-diff-results.ts
+++ b/redux/reducers/results/common/remove-commune-type-diff-results.ts
@@ -1,0 +1,32 @@
+// eslint-disable-next-line no-unused-vars
+import { DotationsDiffState } from "../interfaces";
+
+export function removeCommuneTypeDiffResults(
+  state: DotationsDiffState, index: number,
+): DotationsDiffState {
+  const newDsrCommunes = [...state.communes.dsr.communes];
+  newDsrCommunes.splice(index, 1);
+  const newDsuCommunes = [...state.communes.dsu.communes];
+  newDsuCommunes.splice(index, 1);
+  const newDgfCommunes = [...state.communes.dgf.communes];
+  newDgfCommunes.splice(index, 1);
+
+  return {
+    ...state,
+    communes: {
+      ...state.communes,
+      dgf: {
+        ...state.communes.dgf,
+        communes: newDgfCommunes,
+      },
+      dsr: {
+        ...state.communes.dsr,
+        communes: newDsrCommunes,
+      },
+      dsu: {
+        ...state.communes.dsu,
+        communes: newDsuCommunes,
+      },
+    },
+  };
+}

--- a/redux/reducers/results/common/remove-commune-type-results.ts
+++ b/redux/reducers/results/common/remove-commune-type-results.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line no-unused-vars
+import { DotationsState } from "../interfaces";
+
+export function removeCommuneTypeResults(state: DotationsState, index: number): DotationsState {
+  const newDsrCommunes = [...state.communes.dsr.communes];
+  newDsrCommunes.splice(index, 1);
+  const newDsuCommunes = [...state.communes.dsu.communes];
+  newDsuCommunes.splice(index, 1);
+
+  return {
+    ...state,
+    communes: {
+      ...state.communes,
+      dsr: {
+        ...state.communes.dsr,
+        communes: newDsrCommunes,
+      },
+      dsu: {
+        ...state.communes.dsu,
+        communes: newDsuCommunes,
+      },
+    },
+  };
+}

--- a/redux/reducers/results/plf/dotations.ts
+++ b/redux/reducers/results/plf/dotations.ts
@@ -1,12 +1,15 @@
 /* eslint-disable sort-keys */
 import {
   // eslint-disable-next-line no-unused-vars
+  RemoveCommuneTypeAction,
+  // eslint-disable-next-line no-unused-vars
   SimulateDotationsFailureAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsRequestAction,
   // eslint-disable-next-line no-unused-vars
   SimulateDotationsSuccessAction,
 } from "../../../actions";
+import { removeCommuneTypeResults } from "../common";
 // eslint-disable-next-line no-unused-vars
 import { AsyncState, DotationsState } from "../interfaces";
 
@@ -18,7 +21,8 @@ const DEFAULT_STATE: AsyncState<DotationsState> = {
 type DotationsAction =
   SimulateDotationsFailureAction |
   SimulateDotationsRequestAction |
-  SimulateDotationsSuccessAction;
+  SimulateDotationsSuccessAction |
+  RemoveCommuneTypeAction;
 
 export function dotations(
   state: AsyncState<DotationsState> = DEFAULT_STATE, action: DotationsAction,
@@ -40,6 +44,14 @@ export function dotations(
       // TODO: remove this when the PLF is enabled.
       // state: action.dotations.plf,
       state: action.dotations.base,
+    };
+  case "REMOVE_COMMUNE_TYPE":
+    if (state.state === null) {
+      return state;
+    }
+    return {
+      isFetching: false,
+      state: removeCommuneTypeResults(state.state, action.index),
     };
   default:
     return state;

--- a/styles/theme.js
+++ b/styles/theme.js
@@ -59,7 +59,7 @@ const theme = createMuiTheme({
 
   palette: {
     background: {
-      paper: "rgba(255, 255, 255, 0.7)",
+      paper: "rgba(255, 255, 255, 1)",
       default: "rgba(255, 255, 255, 1)",
     },
     primary: {


### PR DESCRIPTION
Trello : https://trello.com/c/Upn4BRYq/307-ajouter-barre-de-recherche-communes

Pour visualiser la fonctionnalité, ajouter `?search` à l'URL.

Pour l'instant, il n'y a pas d'implémentation côté serveur, donc seules trois villes sont proposées.

Attention : si une ville est déjà dans les cas types, elle ne sera pas ajoutée (penser à en supprimer avant)