### PR TITLE
Ajouter faux PLF

### DIFF
--- a/components/common/simulation-page/SimulationPage.tsx
+++ b/components/common/simulation-page/SimulationPage.tsx
@@ -48,11 +48,6 @@ export class SimulationPage extends PureComponent<Props, State> {
     this.state = { indextab: 0 };
   }
 
-  componentDidMount() {
-    const { initializeAppllicationStoreFromAPI } = this.props;
-    initializeAppllicationStoreFromAPI();
-  }
-
   handleOnChangeIndex = (event, indextab) => {
     this.setState({ indextab });
   };

--- a/components/common/simulation-page/index.ts
+++ b/components/common/simulation-page/index.ts
@@ -2,10 +2,6 @@ import withWidth from "@material-ui/core/withWidth";
 import { connect } from "react-redux";
 import { compose } from "redux";
 
-import {
-  fetchMetadataCasTypes,
-  simulateCasTypes,
-} from "../../../redux/actions";
 import { SimulationPage } from "./SimulationPage";
 
 const mapStateToProps = (state, { width }) => {
@@ -13,22 +9,7 @@ const mapStateToProps = (state, { width }) => {
   return { useMobileView };
 };
 
-const mapDispatchToProps = dispatch => ({
-  initializeAppllicationStoreFromAPI: () => {
-    // rempli le store de l'application avec les données
-    // provenant de l'API
-    dispatch(fetchMetadataCasTypes()).then(() => {
-      // lance le calcul des cas types la premiere fois
-      // que le reformeur s'affiche
-      dispatch(simulateCasTypes());
-    });
-  },
-});
-
 export default compose(
   withWidth(),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps),
 )(SimulationPage);

--- a/components/ir/cartes-impact/carte-etat/bar-chart.jsx
+++ b/components/ir/cartes-impact/carte-etat/bar-chart.jsx
@@ -40,7 +40,7 @@ class BarChart extends PureComponent {
       result.push(resapres);
     }
 
-    return result;
+    return result.reverse();
   };
 
   render() {

--- a/pages/dotations.tsx
+++ b/pages/dotations.tsx
@@ -10,9 +10,10 @@ import { SimulationPage } from "../components/common";
 import { Articles, Results } from "../components/dotations";
 import PopinManager from "../components/PopinManager";
 import withRoot from "../lib/withRoot";
-import { simulateDotations } from "../redux/actions";
+import { initFakePlf, simulateDotations } from "../redux/actions";
 
 const mapDispatchToProps = dispatch => ({
+  addFakePlf: () => dispatch(initFakePlf()),
   simulate: () => dispatch(simulateDotations()),
 });
 
@@ -21,6 +22,14 @@ const connector = connect(null, mapDispatchToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 class DotationPage extends PureComponent<PropsFromRedux> {
+  componentDidMount() {
+    const { addFakePlf } = this.props;
+    const url = new URLSearchParams(window.location.search);
+    if (url.has("fauxplf")) {
+      addFakePlf();
+    }
+  }
+
   render() {
     const { simulate } = this.props;
     return (

--- a/pages/ir.tsx
+++ b/pages/ir.tsx
@@ -13,7 +13,8 @@ import { Articles, CartesImpact as ImpactCards } from "../components/ir";
 import PopinManager from "../components/PopinManager";
 import withRoot from "../lib/withRoot";
 import {
-  disabledEtat, fetchSimPop, showAddCasTypesPopin, simulateCasTypes,
+  disabledEtat, fetchMetadataCasTypes,
+  fetchSimPop, showAddCasTypesPopin, simulateCasTypes,
 } from "../redux/actions";
 // eslint-disable-next-line no-unused-vars
 import { RootState } from "../redux/reducers";
@@ -23,6 +24,7 @@ const mapStateToProps = ({ token }: RootState) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  init: () => dispatch(fetchMetadataCasTypes()).then(() => dispatch(simulateCasTypes())),
   showAddCasTypesPopin: () => dispatch(showAddCasTypesPopin()),
   simulateCasTypes: () => {
     dispatch(simulateCasTypes());
@@ -51,7 +53,12 @@ type Props = PropsFromRedux & {
 
 }
 
-class IndexPage extends PureComponent<Props> {
+class IRPage extends PureComponent<Props> {
+  componentDidMount() {
+    const { init } = this.props;
+    init();
+  }
+
   render() {
     const {
       // eslint-disable-next-line no-shadow
@@ -111,4 +118,4 @@ export default flow(
   withRouter,
   withRoot,
   connector,
-)(IndexPage);
+)(IRPage);

--- a/redux/actions/parameters/index.ts
+++ b/redux/actions/parameters/index.ts
@@ -1,4 +1,5 @@
 export * from "./add-new-line-in-parameter-array";
+export * from "./init-fake-plf";
 export * from "./remove-last-line-in-parameter-array";
 export * from "./reset-amendement-to-base";
 export * from "./reset-amendement-to-plf";

--- a/redux/actions/parameters/init-fake-plf.ts
+++ b/redux/actions/parameters/init-fake-plf.ts
@@ -1,0 +1,9 @@
+export interface InitFakePlfAction {
+  type: "INIT_FAKE_PLF",
+}
+
+export function initFakePlf(): InitFakePlfAction {
+  return {
+    type: "INIT_FAKE_PLF",
+  };
+}

--- a/redux/reducers/parameters/amendement/dotations.ts
+++ b/redux/reducers/parameters/amendement/dotations.ts
@@ -1,7 +1,8 @@
+import { setIn } from "immutable";
 import { cloneDeep } from "lodash";
 
 // eslint-disable-next-line no-unused-vars
-import { ResetAmendementToBaseAction, ResetAmendementToPlfAction } from "../../../actions";
+import { InitFakePlfAction, ResetAmendementToBaseAction, ResetAmendementToPlfAction } from "../../../actions";
 import { BASE_DOTATIONS_DEFAULT_STATE } from "../base";
 // eslint-disable-next-line no-unused-vars
 import { DotationsState } from "../interfaces";
@@ -9,7 +10,10 @@ import { PLF_DOTATIONS_DEFAULT_STATE } from "../plf";
 
 const AMENDEMENT_DOTATIONS_DEFAULT_STATE = cloneDeep(PLF_DOTATIONS_DEFAULT_STATE);
 
-type DotationsAction = ResetAmendementToBaseAction|ResetAmendementToPlfAction;
+type DotationsAction =
+ ResetAmendementToBaseAction |
+ ResetAmendementToPlfAction |
+ InitFakePlfAction;
 
 export function dotations(
   state: DotationsState = AMENDEMENT_DOTATIONS_DEFAULT_STATE, action: DotationsAction,
@@ -25,6 +29,8 @@ export function dotations(
       return cloneDeep(BASE_DOTATIONS_DEFAULT_STATE);
     }
     return state;
+  case "INIT_FAKE_PLF":
+    return setIn(state, ["communes", "dsr", "eligibilite", "popMax"], 15000);
   default:
     return state;
   }

--- a/redux/reducers/parameters/amendement/dotations.ts
+++ b/redux/reducers/parameters/amendement/dotations.ts
@@ -30,7 +30,10 @@ export function dotations(
     }
     return state;
   case "INIT_FAKE_PLF":
-    return setIn(state, ["communes", "dsr", "eligibilite", "popMax"], 15000);
+    let newState: DotationsState = state;
+    newState = setIn(newState, ["communes", "dsr", "eligibilite", "popMax"], 8000);
+    newState = setIn(newState, ["communes", "dsr", "eligibilite", "popChefLieuMax"], 18000);
+    return newState;
   default:
     return state;
   }

--- a/redux/reducers/parameters/plf/dotations.ts
+++ b/redux/reducers/parameters/plf/dotations.ts
@@ -117,7 +117,10 @@ export function dotations(
 ): DotationsState {
   switch (action.type) {
   case "INIT_FAKE_PLF":
-    return setIn(state, ["communes", "dsr", "eligibilite", "popMax"], 15000);
+    let newState: DotationsState = state;
+    newState = setIn(newState, ["communes", "dsr", "eligibilite", "popMax"], 8000);
+    newState = setIn(newState, ["communes", "dsr", "eligibilite", "popChefLieuMax"], 18000);
+    return newState;
   default:
     return state;
   }

--- a/redux/reducers/parameters/plf/dotations.ts
+++ b/redux/reducers/parameters/plf/dotations.ts
@@ -1,6 +1,11 @@
 /* eslint-disable sort-keys */
 
 // eslint-disable-next-line no-unused-vars
+import { setIn } from "immutable";
+
+// eslint-disable-next-line no-unused-vars
+import { InitFakePlfAction } from "../../../actions";
+// eslint-disable-next-line no-unused-vars
 import { DotationsState } from "../interfaces";
 
 export const PLF_DOTATIONS_DEFAULT_STATE: DotationsState = {
@@ -105,4 +110,15 @@ export const PLF_DOTATIONS_DEFAULT_STATE: DotationsState = {
   },
 };
 
-export const dotations = (state = PLF_DOTATIONS_DEFAULT_STATE) => state;
+type DotationsType = InitFakePlfAction;
+
+export function dotations(
+  state: DotationsState = PLF_DOTATIONS_DEFAULT_STATE, action: DotationsType,
+): DotationsState {
+  switch (action.type) {
+  case "INIT_FAKE_PLF":
+    return setIn(state, ["communes", "dsr", "eligibilite", "popMax"], 15000);
+  default:
+    return state;
+  }
+}


### PR DESCRIPTION
https://trello.com/c/nSfpGr4C/414-r%C3%A9fl%C3%A9chir-%C3%A0-un-faux-plf-exemple-pour-les-futures-d%C3%A9mos

On peut voir un faux PLF en ajoutant `?fauxplf` à l'URL. Seul un champs est modifié dans ce PLF. Le serveur ne renvoie pas les résultats PLF.

Cette PR corrige par la même occasion (même partie du code) : https://trello.com/c/OuR6md8K/329-ne-pas-lancer-la-simulation-ir-lorsquon-est-sur-la-page-dotations

Cette PR corrige par la même occasion : https://trello.com/c/gDCMfNPY/408-valeurs-du-graphique-ir-incoh%C3%A9rentes