### PR TITLE
Corriger le bug "revenu" sur l'IR

### DIFF
--- a/components/common/utils/transform-data-to-cas-types.ts
+++ b/components/common/utils/transform-data-to-cas-types.ts
@@ -102,7 +102,7 @@ export const transformDataToCasTypes = (datas): CasType[] => datas.map((data) =>
     nbCouple,
     nbEnfants,
     persons: { childs, parents },
-    revenusNetMensuel: revenusAnnuel / 12,
+    revenusNetMensuel: Math.round(revenusAnnuel / 12),
   };
 });
 

--- a/components/ir/ajouter-cas-types/index.ts
+++ b/components/ir/ajouter-cas-types/index.ts
@@ -34,7 +34,7 @@ const DEFAULT_CAS_TYPES: CasType = {
     childs: [],
     parents: [{ ...DEFAULT_PERSON_VALUES, gender: randomGender() }],
   },
-  revenusNetMensuel: 500,
+  revenusNetMensuel: 1200,
 };
 
 const mapStateToProps = ({ descriptions }: RootState, { index }) => {


### PR DESCRIPTION
Trello : https://trello.com/c/TH1uVHKd/316-bug-revenu-lors-de-l%C3%A9dition

Bug : lorsque je clique sur le bouton "éditer" sur le foyer fiscal `1 300 €/mois`, la popup qui s'ouvre affiche un revenu affiché de `500 €/mois`

Cette PR corrige ce bug :
- sur tous les cas types lorsque l'utilisateur n'est pas connecté,
- sur les nouveaux cas types ou cas types édités lorsque l'utilisateur est connecté.