### PR TITLE
Ne pas séparer le symbole € ou % de son nombre lors des retours à la ligne

### DIFF
--- a/components/common/articles-inputs/values/ParameterValues.tsx
+++ b/components/common/articles-inputs/values/ParameterValues.tsx
@@ -34,6 +34,7 @@ type Props = PropsFromRedux & {
   offset?: number;
   path: string;
   amendementInputSize?: "small"|"xl";
+  symbol?: string;
 }
 
 function ParameterValues(props: Props) {

--- a/components/common/articles-inputs/values/ResultValues.tsx
+++ b/components/common/articles-inputs/values/ResultValues.tsx
@@ -16,6 +16,7 @@ type Props = PropsFromRedux & {
   decimals?: number;
   path: string;
   amendementInputSize?: "small"|"xl";
+  symbol?: string;
 }
 
 function ResultValues(props: Props) {

--- a/components/common/articles-inputs/values/Values.tsx
+++ b/components/common/articles-inputs/values/Values.tsx
@@ -117,7 +117,6 @@ class Values extends PureComponent<Props & PropsFromRedux> {
           && <span>&nbsp;&nbsp;</span>
         }
         {
-          // eslint-disable-next-line no-nested-ternary
           isDefined(amendementValue) && (
             <span>
               {

--- a/components/common/articles-inputs/values/Values.tsx
+++ b/components/common/articles-inputs/values/Values.tsx
@@ -20,6 +20,7 @@ interface Props {
   onAmendementChange?: (value: number) => void,
   offset?: number;
   plfValue?: number|string|null;
+  symbol?: string;
 }
 
 const mapStateToProps = ({ token }: RootState) => ({
@@ -61,7 +62,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
   render() {
     const {
       amendementInputSize, amendementValue, baseValue,
-      decimals, editable, onAmendementChange, plfValue,
+      decimals, editable, onAmendementChange, plfValue, symbol,
     } = this.props;
 
     let { offset } = this.props;
@@ -117,36 +118,41 @@ class Values extends PureComponent<Props & PropsFromRedux> {
         }
         {
           // eslint-disable-next-line no-nested-ternary
-          isDefined(amendementValue) && (editable
-            ? (
-              typeof amendementValue === "number" ? (
-                <NumberInput
-                  className={classNames({
+          isDefined(amendementValue) && (
+            <span>
+              {
+              // eslint-disable-next-line no-nested-ternary
+                editable ? (
+                  typeof amendementValue === "number" ? (
+                    <NumberInput
+                      className={classNames({
+                        [styles.baseValue]: amendementValue === plfValue && plfValue === baseValue,
+                        [styles.plfValue]: amendementValue === plfValue && plfValue !== baseValue,
+                        [styles.amendementValue]: amendementValue !== plfValue,
+                        // Sizes
+                        [styles.amendementInput]: true,
+                        [styles.smallInput]: amendementInputSize === "small",
+                        [styles.xlInput]: amendementInputSize === "xl",
+                      })}
+                      value={amendementValue + offset}
+                      onChange={onAmendementChange
+                        ? value => onAmendementChange(value - (offset as number))
+                        : (() => {})
+                      }
+                      onEnter={this.runSimulation} />
+                  ) : null
+                ) : (
+                  <span className={classNames({
                     [styles.baseValue]: amendementValue === plfValue && plfValue === baseValue,
                     [styles.plfValue]: amendementValue === plfValue && plfValue !== baseValue,
                     [styles.amendementValue]: amendementValue !== plfValue,
-                    // Sizes
-                    [styles.amendementInput]: true,
-                    [styles.smallInput]: amendementInputSize === "small",
-                    [styles.xlInput]: amendementInputSize === "xl",
-                  })}
-                  value={amendementValue + offset}
-                  onChange={onAmendementChange
-                    ? value => onAmendementChange(value - (offset as number))
-                    : (() => {})
-                  }
-                  onEnter={this.runSimulation} />
-              ) : null
-            )
-            : (
-              <span className={classNames({
-                [styles.baseValue]: amendementValue === plfValue && plfValue === baseValue,
-                [styles.plfValue]: amendementValue === plfValue && plfValue !== baseValue,
-                [styles.amendementValue]: amendementValue !== plfValue,
-              })}>
-                {typeof amendementValue === "string" ? amendementValue : formatNumber(amendementValue + offset, { decimals })}
-              </span>
-            ))
+                  })}>
+                    {typeof amendementValue === "string" ? amendementValue : formatNumber(amendementValue + offset, { decimals })}
+                  </span>
+                )}
+              {symbol && ` ${symbol}`}
+            </span>
+          )
         }
       </span>
     );

--- a/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
+++ b/components/dotations/articles/dsr-fraction-bourg-centre/DsrFractionBourgCentre.tsx
@@ -33,9 +33,10 @@ class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
           editable
           amendementInputSize="small"
           path="dotations.communes.dsr.bourgCentre.eligibilite.partPopCantonMin"
+          symbol="%"
         />
         {" "}
-        % de la population du canton, aux communes
+        de la population du canton, aux communes
         sièges des bureaux centralisateurs, ainsi qu&apos;aux communes chefs-lieux de canton
         au 1er janvier 2014 ;
         <br />
@@ -54,9 +55,10 @@ class DsrFractionBourgCentre extends PureComponent<PropsFromRedux> {
               editable
               amendementInputSize="small"
               path="dotations.communes.dsr.bourgCentre.eligibilite.exclusion.agglomeration.partPopDepartementMin"
+              symbol="%"
             />
             {" "}
-        % de la population du département ou comptant plus de
+            de la population du département ou comptant plus de
             {" "}
             <ParameterValues
               editable

--- a/components/dotations/articles/dsr-fraction-cible/DsrFractionCible.tsx
+++ b/components/dotations/articles/dsr-fraction-cible/DsrFractionCible.tsx
@@ -49,17 +49,18 @@ export class DsrFractionCible extends PureComponent {
           editable
           amendementInputSize="small"
           path="dotations.communes.dsr.cible.eligibilite.indiceSynthetique.ponderationPotentielFinancier"
+          symbol="%"
         />
         {" "}
-        % et le deuxième par
+        et le deuxième par
         {" "}
         <ParameterValues
           editable
           amendementInputSize="small"
           path="dotations.communes.dsr.cible.eligibilite.indiceSynthetique.ponderationRevenu"
+          symbol="%"
         />
-        {" "}
-        %.
+        .
         <br />
         <br />
         <ExpandablePanelSubTitle subTitle="§ 6" title="Répartition" />

--- a/components/dotations/articles/dsr-fraction-perequation/DsrFractionPerequation.tsx
+++ b/components/dotations/articles/dsr-fraction-perequation/DsrFractionPerequation.tsx
@@ -47,9 +47,10 @@ export class DsrFractionPerequation extends PureComponent {
             editable
             amendementInputSize="small"
             path="dotations.communes.dsr.perequation.attribution.repartition.ponderationPotentielFinancier"
+            symbol="%"
           />
           {" "}
-        % de son montant, en fonction de la population pondérée par
+        de son montant, en fonction de la population pondérée par
         l&apos;écart entre le potentiel financier par habitant de la commune et le
         potentiel financier moyen par habitant des communes appartenant au même
         groupe démographique ainsi que par l&apos;effort fiscal plafonné à 1,2 ;
@@ -61,9 +62,10 @@ export class DsrFractionPerequation extends PureComponent {
             editable
             amendementInputSize="small"
             path="dotations.communes.dsr.perequation.attribution.repartition.ponderationLongueurVoirie"
+            symbol="%"
           />
           {" "}
-        % de son montant, proportionnellement à la longueur de la voirie
+        de son montant, proportionnellement à la longueur de la voirie
         classée dans le domaine public communal ; pour les communes situées en zone
         de montagne ou pour les communes insulaires, la longueur de la voirie est
         doublée. Pour l&apos;application du présent article, une commune insulaire
@@ -79,9 +81,10 @@ export class DsrFractionPerequation extends PureComponent {
             editable
             amendementInputSize="small"
             path="dotations.communes.dsr.perequation.attribution.repartition.ponderationNbreEnfants"
+            symbol="%"
           />
           {" "}
-        % de son montant, proportionnellement au nombre d&apos;enfants de
+        de son montant, proportionnellement au nombre d&apos;enfants de
         trois à seize ans domiciliés dans la commune, établi lors du dernier recensement.
           <br />
           <br />
@@ -91,9 +94,10 @@ export class DsrFractionPerequation extends PureComponent {
             editable
             amendementInputSize="small"
             path="dotations.communes.dsr.perequation.attribution.repartition.ponderationPotentielFinancierParHectare"
+            symbol="%"
           />
           {" "}
-        % de son montant au maximum, en fonction de l&apos;écart entre le
+        de son montant au maximum, en fonction de l&apos;écart entre le
         potentiel financier par hectare de la commune et le potentiel financier moyen
         par hectare des communes de moins de
           {" "}

--- a/components/dotations/articles/dsu-eligibilite/DsuEligibilite.tsx
+++ b/components/dotations/articles/dsu-eligibilite/DsuEligibilite.tsx
@@ -24,9 +24,13 @@ export class DsuEligibilite extends PureComponent {
         <span className={styles.bold}>
           Les deux premiers tiers [ les premiers
           {" "}
-          <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.pourcentageRangSeuilHaut" />
+          <ParameterValues
+            editable
+            amendementInputSize="small"
+            path="dotations.communes.dsu.eligibilite.pourcentageRangSeuilHaut"
+            symbol="%" />
           {" "}
-          % ]
+          ]
         </span>
         {" "}
         des communes de
@@ -51,9 +55,13 @@ export class DsuEligibilite extends PureComponent {
         <span className={styles.bold}>
           Le premier dixième [ les premiers
           {" "}
-          <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.pourcentageRangSeuilBas" />
+          <ParameterValues
+            editable
+            amendementInputSize="small"
+            path="dotations.communes.dsu.eligibilite.pourcentageRangSeuilBas"
+            symbol="%" />
           {" "}
-          % ]
+          ]
         </span>
         {" "}
         des communes dont la population est

--- a/components/dotations/articles/dsu-indice/DsuIndice.tsx
+++ b/components/dotations/articles/dsu-indice/DsuIndice.tsx
@@ -145,27 +145,37 @@ export class DsuIndice extends PureComponent {
         <br />
         en pondérant le premier par
         {" "}
-        <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationPotentielFinancier" />
-        {" "}
-        %,
+        <ParameterValues
+          editable
+          amendementInputSize="small"
+          path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationPotentielFinancier"
+          symbol="%" />
         <br />
         le deuxième par
         {" "}
-        <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationLogementsSociaux" />
-        {" "}
-        %,
+        <ParameterValues
+          editable
+          amendementInputSize="small"
+          path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationLogementsSociaux"
+          symbol="%" />
+        ,
         <br />
         le troisième par
         {" "}
-        <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationAideAuLogement" />
-        {" "}
-        %
+        <ParameterValues
+          editable
+          amendementInputSize="small"
+          path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationAideAuLogement"
+          symbol="%" />
         <br />
         et le quatrième par
         {" "}
-        <ParameterValues editable amendementInputSize="small" path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationRevenu" />
-        {" "}
-        %.
+        <ParameterValues
+          editable
+          amendementInputSize="small"
+          path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationRevenu"
+          symbol="%" />
+        .
         <br />
         <br />
         Toutefois, chacun des pourcentages de pondération peut être majoré ou

--- a/components/dotations/articles/dsu-indice/DsuIndice.tsx
+++ b/components/dotations/articles/dsu-indice/DsuIndice.tsx
@@ -150,6 +150,7 @@ export class DsuIndice extends PureComponent {
           amendementInputSize="small"
           path="dotations.communes.dsu.eligibilite.indiceSynthetique.ponderationPotentielFinancier"
           symbol="%" />
+          ,
         <br />
         le deuxième par
         {" "}

--- a/components/dotations/articles/montant-dgf/MontantDgf.tsx
+++ b/components/dotations/articles/montant-dgf/MontantDgf.tsx
@@ -51,9 +51,9 @@ export class MontantDgf extends PureComponent {
         {" "}
         <ParameterValues
           amendementInputSize="xl"
-          path="dotations.montants.dgf" />
-        {" "}
-        €.
+          path="dotations.montants.dgf"
+          symbol="€" />
+        .
       </Fragment>
     );
   }

--- a/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
+++ b/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
@@ -97,8 +97,10 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       <td className={styles.light} rowSpan={2}>
                         {formatNumber(
                           strate.description.potentielFinancierMoyenParHab,
-                          { decimals: 2 },
+                          { decimals: 0 },
                         )}
+                        {" "}
+                        €
                       </td>
                       <td>
                         <LocalFloristIcon />
@@ -110,16 +112,14 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       <td>
                         <ResultValues
                           decimals={2}
-                          path={`dotations.state.communes.dsr.strates.${index}.dotationMoyenneParHab`} />
-                        {" "}
-                        €
+                          path={`dotations.state.communes.dsr.strates.${index}.dotationMoyenneParHab`}
+                          symbol="€" />
                       </td>
                       <td>
                         <ResultValues
                           decimals={0}
-                          path={`dotations.state.communes.dsr.strates.${index}.partDotationTotale`} />
-                        {" "}
-                        %
+                          path={`dotations.state.communes.dsr.strates.${index}.partDotationTotale`}
+                          symbol="%" />
                       </td>
                     </tr>
                     <tr key={strate.description.habitants * 2 + 1}>
@@ -133,16 +133,14 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       <td>
                         <ResultValues
                           decimals={2}
-                          path={`dotations.state.communes.dsu.strates.${index}.dotationMoyenneParHab`} />
-                        {" "}
-                        €
+                          path={`dotations.state.communes.dsu.strates.${index}.dotationMoyenneParHab`}
+                          symbol="€" />
                       </td>
                       <td>
                         <ResultValues
                           decimals={0}
-                          path={`dotations.state.communes.dsu.strates.${index}.partDotationTotale`} />
-                        {" "}
-                        %
+                          path={`dotations.state.communes.dsu.strates.${index}.partDotationTotale`}
+                          symbol="%" />
                       </td>
                     </tr>
                   </Fragment>

--- a/components/ir/articles/articles-component.jsx
+++ b/components/ir/articles/articles-component.jsx
@@ -57,10 +57,11 @@ class ArticlesComponent extends React.Component {
             amendementValue={s[i]}
             baseValue={baseValue}
             plfValue={plfValue}
+            symbol="€"
             onAmendementChange={value => handleArticleChange(value, `seuil${i}`)}
           />
           {" "}
-          € le taux de&nbsp;:
+          le taux de&nbsp;:
         </div>
       );
     }
@@ -83,10 +84,9 @@ class ArticlesComponent extends React.Component {
             amendementValue={t[i - 1]}
             baseValue={baseValuet}
             plfValue={plfValuet}
+            symbol="%"
             onAmendementChange={value => handleArticleChange(value, `taux${i - 1}`)}
           />
-          {" "}
-          %
           <br />
           pour la fraction supérieure à
           {" "}
@@ -95,9 +95,9 @@ class ArticlesComponent extends React.Component {
             baseValue={baseValue}
             editable={false}
             plfValue={plfValue}
+            symbol="€"
           />
-          {" "}
-          €.
+          .
         </div>
       );
     }
@@ -121,10 +121,9 @@ class ArticlesComponent extends React.Component {
           amendementValue={t[i - 1]}
           baseValue={baseValuet}
           plfValue={plfValuet}
+          symbol="%"
           onAmendementChange={value => handleArticleChange(value, `taux${i - 1}`)}
         />
-        {" "}
-        %
         <br />
         pour la fraction supérieure à
         {" "}
@@ -133,9 +132,8 @@ class ArticlesComponent extends React.Component {
           baseValue={baseValueminus1}
           editable={false}
           plfValue={plfValueminus1}
+          symbol="€"
         />
-        {" "}
-        €
         <br />
         et inférieure ou égale à
         {" "}
@@ -144,10 +142,11 @@ class ArticlesComponent extends React.Component {
           amendementValue={s[i]}
           baseValue={baseValue}
           plfValue={plfValue}
+          symbol="€"
           onAmendementChange={value => handleArticleChange(value, `seuil${i}`)}
         />
         {" "}
-        € ;
+        ;
       </div>
     );
   };

--- a/components/ir/cartes-impact/simple-card/impact-impots.tsx
+++ b/components/ir/cartes-impact/simple-card/impact-impots.tsx
@@ -53,12 +53,11 @@ class SimpleCardImpactImpots extends PureComponent<PropsFromRedux & Props> {
           <div className={styles.result}>
             <NeutralTooltip
               placement="bottom-start"
-              title={title || <span>caca</span>}>
+              title={title || <span />}>
               <span>
                 <ResultValues
-                  path={`ir.state.casTypes.${index}.impotAnnuel`} />
-                {" "}
-                €
+                  path={`ir.state.casTypes.${index}.impotAnnuel`}
+                  symbol="€" />
               </span>
             </NeutralTooltip>
           </div>


### PR DESCRIPTION
https://trello.com/c/vS876OwP/421-l%E2%82%AC-qui-revient-tout-seul-%C3%A0-la-ligne-cest-moche

Cette PR ajoute aussi le symbole "€" dans la colonne _Potentiel financier moyen par hab_ et supprimer les virgules pour être cohérent avec les cas types.

Pour la revue, utiliser cette URL : https://github.com/leximpact/leximpact-client/pull/93/files?w=1