### PR TITLE
Ajouter "proportion communes eligibles".

### DIFF
--- a/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
+++ b/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
@@ -47,7 +47,7 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
               </th>
               <th />
               <th rowSpan={2}>
-                Nombre
+                Proportion
                 <br />
                 de communes éligibles
               </th>
@@ -107,7 +107,9 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       </td>
                       <td>
                         <ResultValues
-                          path={`dotations.state.communes.dsr.strates.${index}.eligibles`} />
+                          decimals={0}
+                          path={`dotations.state.communes.dsr.strates.${index}.proportionEligibles`}
+                          symbol="%" />
                       </td>
                       <td>
                         <ResultValues
@@ -128,7 +130,9 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       </td>
                       <td>
                         <ResultValues
-                          path={`dotations.state.communes.dsu.strates.${index}.eligibles`} />
+                          decimals={0}
+                          path={`dotations.state.communes.dsu.strates.${index}.proportionEligibles`}
+                          symbol="%" />
                       </td>
                       <td>
                         <ResultValues

--- a/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
+++ b/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
@@ -108,7 +108,7 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       <td>
                         <ResultValues
                           decimals={0}
-                          path={`dotations.state.communes.dsr.strates.${index}.proportionEligibles`}
+                          path={`dotations.state.communes.dsr.strates.${index}.partEligibles`}
                           symbol="%" />
                       </td>
                       <td>
@@ -131,7 +131,7 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                       <td>
                         <ResultValues
                           decimals={0}
-                          path={`dotations.state.communes.dsu.strates.${index}.proportionEligibles`}
+                          path={`dotations.state.communes.dsu.strates.${index}.partEligibles`}
                           symbol="%" />
                       </td>
                       <td>

--- a/redux/actions/simulations/simulate-dotations.ts
+++ b/redux/actions/simulations/simulate-dotations.ts
@@ -145,6 +145,7 @@ interface ResponseBody {
         strates: {
           // Nombre de communes éligibles
           eligibles: number;
+          proportionEligibles: number;
           // Dotation moyenne par habitant
           dotationMoyenneParHab: number;
           // Part des dotations accordées à cette strate dans la dotation totale.
@@ -163,6 +164,7 @@ interface ResponseBody {
         strates: {
           // Nombre de communes éligibles
           eligibles: number;
+          proportionEligibles: number;
           // Dotation moyenne par habitant
           dotationMoyenneParHab: number;
           // Part des dotations accordées à cette strate dans la dotation totale.
@@ -298,16 +300,22 @@ export const simulateDotations = () => (dispatch, getState) => {
         payload.amendement.communes[dotation].strates.forEach((strate) => {
           // eslint-disable-next-line no-param-reassign
           strate.partDotationTotale *= 100;
+          // eslint-disable-next-line no-param-reassign
+          strate.proportionEligibles *= 100;
         });
         if (payload.plf) {
           payload.plf.communes[dotation].strates.forEach((strate) => {
             // eslint-disable-next-line no-param-reassign
             strate.partDotationTotale *= 100;
+            // eslint-disable-next-line no-param-reassign
+            strate.proportionEligibles *= 100;
           });
         }
         payload.base.communes[dotation].strates.forEach((strate) => {
           // eslint-disable-next-line no-param-reassign
           strate.partDotationTotale *= 100;
+          // eslint-disable-next-line no-param-reassign
+          strate.proportionEligibles *= 100;
         });
       }
 

--- a/redux/actions/simulations/simulate-dotations.ts
+++ b/redux/actions/simulations/simulate-dotations.ts
@@ -145,7 +145,7 @@ interface ResponseBody {
         strates: {
           // Nombre de communes éligibles
           eligibles: number;
-          proportionEligibles: number;
+          partEligibles: number;
           // Dotation moyenne par habitant
           dotationMoyenneParHab: number;
           // Part des dotations accordées à cette strate dans la dotation totale.
@@ -164,7 +164,7 @@ interface ResponseBody {
         strates: {
           // Nombre de communes éligibles
           eligibles: number;
-          proportionEligibles: number;
+          partEligibles: number;
           // Dotation moyenne par habitant
           dotationMoyenneParHab: number;
           // Part des dotations accordées à cette strate dans la dotation totale.
@@ -301,21 +301,21 @@ export const simulateDotations = () => (dispatch, getState) => {
           // eslint-disable-next-line no-param-reassign
           strate.partDotationTotale *= 100;
           // eslint-disable-next-line no-param-reassign
-          strate.proportionEligibles *= 100;
+          strate.partEligibles *= 100;
         });
         if (payload.plf) {
           payload.plf.communes[dotation].strates.forEach((strate) => {
             // eslint-disable-next-line no-param-reassign
             strate.partDotationTotale *= 100;
             // eslint-disable-next-line no-param-reassign
-            strate.proportionEligibles *= 100;
+            strate.partEligibles *= 100;
           });
         }
         payload.base.communes[dotation].strates.forEach((strate) => {
           // eslint-disable-next-line no-param-reassign
           strate.partDotationTotale *= 100;
           // eslint-disable-next-line no-param-reassign
-          strate.proportionEligibles *= 100;
+          strate.partEligibles *= 100;
         });
       }
 

--- a/redux/reducers/results/interfaces/dotations-state.ts
+++ b/redux/reducers/results/interfaces/dotations-state.ts
@@ -5,6 +5,7 @@ export interface DotationsState {
       strates: {
         // Nombre de communes éligibles
         eligibles: number;
+        proportionEligibles: number;
         // Dotation moyenne par habitant
         dotationMoyenneParHab: number;
         // Part des dotations accordées à cette strate dans la dotation totale.
@@ -23,6 +24,7 @@ export interface DotationsState {
       strates: {
         // Nombre de communes éligibles
         eligibles: number;
+        proportionEligibles: number;
         // Dotation moyenne par habitant
         dotationMoyenneParHab: number;
         // Part des dotations accordées à cette strate dans la dotation totale.

--- a/redux/reducers/results/interfaces/dotations-state.ts
+++ b/redux/reducers/results/interfaces/dotations-state.ts
@@ -5,7 +5,7 @@ export interface DotationsState {
       strates: {
         // Nombre de communes éligibles
         eligibles: number;
-        proportionEligibles: number;
+        partEligibles: number;
         // Dotation moyenne par habitant
         dotationMoyenneParHab: number;
         // Part des dotations accordées à cette strate dans la dotation totale.
@@ -24,7 +24,7 @@ export interface DotationsState {
       strates: {
         // Nombre de communes éligibles
         eligibles: number;
-        proportionEligibles: number;
+        partEligibles: number;
         // Dotation moyenne par habitant
         dotationMoyenneParHab: number;
         // Part des dotations accordées à cette strate dans la dotation totale.


### PR DESCRIPTION
https://trello.com/c/124jhoWk/372-tableau-mettre-le-pourcentage-de-communes-%C3%A9ligibles-et-non-le-nombre