### PR TITLE
Update dgcl data date in information panel

### DIFF
--- a/components/dotations/results/Results.tsx
+++ b/components/dotations/results/Results.tsx
@@ -37,7 +37,7 @@ class Results extends PureComponent<Props> {
                 name={INFORMATION_PANEL_NAME}
                 title="Les montants des dotations calculées ci-dessous sont des estimations."
               >
-                Les dotations de LexImpact s’appuient sur les données de l’année 2019. Elles
+                Les dotations de LexImpact s’appuient sur les données de l’année 2020. Elles
                 peuvent donc différer des montants effectivement perçus l’année prochaine.
                 Seuls les montants calculés par la DGCL font foi.
               </InformationPanel>


### PR DESCRIPTION
Connected to leximpact/leximpact-server#35

Met à jour le message d'information concernant la précision des calcul suite à l'emploi de données DGCL 2020 (en place des données 2019).