### PR TITLE
Fixer l'entête du tableau des communes & parts QF & nombres à virgules

### DIFF
--- a/components/common/articles-inputs/values/ResultValues.tsx
+++ b/components/common/articles-inputs/values/ResultValues.tsx
@@ -17,6 +17,7 @@ type Props = PropsFromRedux & {
   path: string;
   amendementInputSize?: "small"|"xl";
   symbol?: string;
+  background?: "part";
 }
 
 function ResultValues(props: Props) {

--- a/components/common/articles-inputs/values/Values.module.scss
+++ b/components/common/articles-inputs/values/Values.module.scss
@@ -4,9 +4,27 @@
   font-weight: bold;
 }
 
+.part {
+  height: 46px;
+  width: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.baseValue.part {
+  background: center/100% url("/static/images/base-part.svg") no-repeat;
+}
+
 .plfValue {
   font-weight: bold;
   color: $plf-color;
+}
+
+.plfValue.part {
+  color: black;
+  background: center/100% url("/static/images/plf-part.svg") no-repeat;
 }
 
 .replacedWithPlf {
@@ -36,6 +54,10 @@
   padding: 0.1rem;
   margin: -0.1rem;
   background-color: $amendement-bg-color;
+}
+
+.amendementValue.part {
+  background: center/100% url("/static/images/amendement-part.svg") no-repeat;
 }
 
 .noOverflow > span {

--- a/components/common/articles-inputs/values/Values.tsx
+++ b/components/common/articles-inputs/values/Values.tsx
@@ -21,6 +21,7 @@ interface Props {
   offset?: number;
   plfValue?: number|string|null;
   symbol?: string;
+  background?: "part";
 }
 
 const mapStateToProps = ({ token }: RootState) => ({
@@ -61,7 +62,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
 
   render() {
     const {
-      amendementInputSize, amendementValue, baseValue,
+      amendementInputSize, amendementValue, background, baseValue,
       decimals, editable, onAmendementChange, plfValue, symbol,
     } = this.props;
 
@@ -93,6 +94,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
         {
           isDefined(baseValue) && !isEqual(baseValue, plfValue) && (
             <span className={classNames({
+              [styles.part]: background === "part",
               [styles.baseValue]: true,
               [styles.replacedWithPlf]: !isEqual(plfValue, baseValue),
               [styles.replacedWithAmendement]: isEqual(plfValue, baseValue)
@@ -111,6 +113,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
         {
           isDefined(plfValue) && !isEqual(amendementValue, plfValue) && (
             <span className={classNames({
+              [styles.part]: background === "part",
               [styles.baseValue]: isEqual(baseValue, plfValue),
               [styles.plfValue]: !isEqual(baseValue, plfValue),
               [styles.replacedWithAmendement]: !isEqual(amendementValue, plfValue),
@@ -153,6 +156,7 @@ class Values extends PureComponent<Props & PropsFromRedux> {
                   ) : null
                 ) : (
                   <span className={classNames({
+                    [styles.part]: background === "part",
                     [styles.baseValue]: isEqual(amendementValue, plfValue)
                       && isEqual(plfValue, baseValue),
                     [styles.plfValue]: isEqual(amendementValue, plfValue)

--- a/components/common/utils/format-number.ts
+++ b/components/common/utils/format-number.ts
@@ -12,7 +12,7 @@ function formatNumber(
     // https://stackoverflow.com/a/32013016/3942056
     // (?=pattern) is the lookahead, \d{3} is 3 digits, and (pattern)+ meansrepeat the
     // last pattern one or more times (greedily) until a the end of the String $
-    .replace(/(\d)(?=(\d{3})+$)/g, "$1 ");
+    .replace(/(\d)(?=(\d{3})+($|,))/g, "$1 ");
 
   if (options.sign && number > 0) {
     return `+${result}`;

--- a/components/common/utils/tests/format-number.test.js
+++ b/components/common/utils/tests/format-number.test.js
@@ -29,4 +29,11 @@ describe("formatNumber", () => {
 
     expect(actual).toBe(expected);
   });
+
+  test("should separate thousands with spaces (decimal numbers).", () => {
+    const expected = "1 000 000,64 899";
+    const actual = formatNumber(1000000.64899);
+
+    expect(actual).toBe(expected);
+  });
 });

--- a/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.module.scss
+++ b/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.module.scss
@@ -14,6 +14,15 @@
   thead {
     th {
       vertical-align: top;
+      position: sticky;
+      top: 0px;
+      background-color: white;
+    }
+
+    tr:last-child {
+      th {
+        top: 30px;
+      }
     }
 
     tr:first-child {

--- a/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
+++ b/components/dotations/results/commune-strate-details/commune-strate-details-table/CommuneStrateDetailsTable.tsx
@@ -45,7 +45,7 @@ class CommuneStrateDetailsTable extends PureComponent<Props> {
                 {/* <br />
                 <span className={styles.link}>[replier ces colonnes]</span> */}
               </th>
-              <th />
+              <th rowSpan={2} />
               <th rowSpan={2}>
                 Proportion
                 <br />

--- a/components/ir/cartes-impact/simple-card/impact-impots.module.scss
+++ b/components/ir/cartes-impact/simple-card/impact-impots.module.scss
@@ -11,6 +11,7 @@
   > div:last-child {
     display: flex;
     flex-direction: column;
+    max-width: 100px;
   }
 }
 

--- a/components/ir/cartes-impact/simple-card/impact-impots.module.scss
+++ b/components/ir/cartes-impact/simple-card/impact-impots.module.scss
@@ -18,7 +18,7 @@
   flex: 1;
   display: flex;
   justify-content: center;
-  padding-top: 15px;
+  padding-top: 5px;
 }
 
 .result {

--- a/components/ir/cartes-impact/simple-card/impact-impots.tsx
+++ b/components/ir/cartes-impact/simple-card/impact-impots.tsx
@@ -65,7 +65,7 @@ class SimpleCardImpactImpots extends PureComponent<PropsFromRedux & Props> {
         <div>
           <div className={styles.legend}>Nbre de parts</div>
           <div className={styles.part}>
-            <ResultValues path={`ir.state.casTypes.${index}.parts`} />
+            <ResultValues background="part" path={`ir.state.casTypes.${index}.parts`} />
           </div>
         </div>
       </div>

--- a/public/static/images/amendement-part.svg
+++ b/public/static/images/amendement-part.svg
@@ -1,0 +1,10 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<path d="M27.4499 2.97174C10.9308 8.07768 0.677975 24.6621 3.49403 41.7214C3.72217 43.1035 4.95885 44.0631 6.35957 44.0515L45.235 43.7298C47.4431 43.7115 48.8755 41.3945 47.9048 39.4111L30.8151 4.49346C30.1993 3.23535 28.7881 2.5581 27.4499 2.97174Z" fill="#ded500"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="50" height="50" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/static/images/base-part.svg
+++ b/public/static/images/base-part.svg
@@ -1,0 +1,10 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<path d="M27.4499 2.97174C10.9308 8.07768 0.677975 24.6621 3.49403 41.7214C3.72217 43.1035 4.95885 44.0631 6.35957 44.0515L45.235 43.7298C47.4431 43.7115 48.8755 41.3945 47.9048 39.4111L30.8151 4.49346C30.1993 3.23535 28.7881 2.5581 27.4499 2.97174Z" fill="#DADADA"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="50" height="50" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/static/images/plf-part.svg
+++ b/public/static/images/plf-part.svg
@@ -1,0 +1,10 @@
+<svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<path d="M27.4499 2.97174C10.9308 8.07768 0.677975 24.6621 3.49403 41.7214C3.72217 43.1035 4.95885 44.0631 6.35957 44.0515L45.235 43.7298C47.4431 43.7115 48.8755 41.3945 47.9048 39.4111L30.8151 4.49346C30.1993 3.23535 28.7881 2.5581 27.4499 2.97174Z" fill="#ff6b6b"/>
+</g>
+<defs>
+<clipPath id="clip0">
+<rect width="50" height="50" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
https://trello.com/c/xZnMm6C1/480-voir-la-l%C3%A9gende-du-tableau-quand-on-scrolle
https://trello.com/c/YN5VVcxc/347-bien-afficher-les-nombres-%C3%A0-virgule
https://trello.com/c/ehWVyYFM/442-design-final-nombre-de-parts

Cette PR :
- fixe l'entête du tableau des communes lorsque l'on "scrolle" ;
- affiche correctement les nombres à virgule en séparant les milliers par des blancs ;
- améliorer l'UI des parts du QF.

A noter :
- Les parts du QF ont des imperfections (mauvais centrage du nombre dans certains cas et ils ne sont pas superposables).
- L'entête tableau peut légèrement "bogger" sur certaines tailles d'écran improbable sans que cela puisse gêner sa lecture.